### PR TITLE
fix: 旧版が残した孤児 subscription を登録時に掃除する (capsicum#949)

### DIFF
--- a/lib/relay/database.rb
+++ b/lib/relay/database.rb
@@ -19,6 +19,11 @@ module Relay
       'device_id', 'created_at', 'updated_at'
     ].freeze
 
+    # device_id を持たない古い行を掃除してよいと判断するまでの猶予 (capsicum#949)。
+    # 生きている端末は起動のたびに register して updated_at が進むので、これを
+    # 超えるのは実際に使われていない行だけになる。詳細は purge_legacy_rows 参照。
+    LEGACY_ROW_GRACE_DAYS = 14
+
     def initialize(logger: Logger.new($stdout))
       @logger = logger
       @db = SQLite3::Database.new(DB_PATH)
@@ -44,10 +49,14 @@ module Relay
       return register_by_token(token, device_type, account, server) unless device_id
 
       row = adoptable_row(token, account, server, device_id)
-      return update_registration(row, token, device_type, device_id) if row
-
-      insert_registration(token, device_type, account, server, device_id)
-      return find_by_composite(token, account, server)
+      current = if row
+        update_registration(row, token, device_type, device_id)
+      else
+        insert_registration(token, device_type, account, server, device_id)
+        find_by_composite(token, account, server)
+      end
+      purge_legacy_rows(account, server, device_type, current['id'])
+      return current
     end
 
     def unregister(id)
@@ -249,6 +258,51 @@ module Relay
       )
       @db.execute('DELETE FROM subscriptions WHERE id = ?', [by_device['id']])
       return by_token
+    end
+
+    # device_id を持たない古い行のうち、**同じ端末の旧版が残したもの**を掃除する
+    # (capsicum#949)。
+    #
+    # device_id 導入前 (capsicum#932 以前) のクライアントは、push トークンが変わる
+    # たびに新しい行を作っていた。その行は上流 (Mastodon / Misskey) の購読が生きて
+    # いる限り push され続けるため、**1 通の通知が行数ぶん増殖する**。2026-08-10 に
+    # 実機で確認した例では windows 3 行 = 3 通で、行を消したら 1 通に戻った。
+    #
+    # 消す条件は 3 つ揃ったときだけ:
+    #
+    # 1. `device_id` が無い（＝旧版が作った行）
+    # 2. 同じ (account, server, device_type) に **device_id 付きの行が既にある**
+    #    ＝そのインストールは新版へ更新済みで、この行はもう誰も更新しない
+    # 3. [LEGACY_ROW_GRACE_DAYS] 以上更新されていない
+    #
+    # 3 が要るのは、**同じ OS の別の実機がまだ旧版で動いている**場合を巻き込まない
+    # ため。生きている端末は起動のたびに register して updated_at が進むので、
+    # 猶予を超えるのは実際に使われていない行だけになる。仮に巻き込んでも、その端末
+    # は次の起動で再登録されるので自己修復する（起動までの間だけ不達）。
+    #
+    # 上流の購読は消さない（消せない）が、行が無くなれば `/push/{push_token}` が
+    # 410 Gone を返し、上流がその購読を破棄する（app.rb 参照）。カスケードで消える。
+    #
+    # クライアントは起動ごとに register するので、専用のスイープ機構は置かない。
+    # 使われているインストールから順に、自然に掃除されていく。
+    def purge_legacy_rows(account, server, device_type, keep_id)
+      grace = "-#{LEGACY_ROW_GRACE_DAYS} days"
+      stale = @db.execute(<<~SQL, [account, server, device_type, keep_id, grace])
+        SELECT id, updated_at FROM subscriptions
+        WHERE account = ? AND server = ? AND device_type = ?
+          AND device_id IS NULL
+          AND id != ?
+          AND updated_at < datetime('now', ?)
+      SQL
+      return if stale.empty?
+
+      stale.each do |row|
+        @logger.info(
+          "Purging legacy subscription id=#{row['id']} (#{account}/#{device_type}," \
+            " last seen #{row['updated_at']})",
+        )
+        @db.execute('DELETE FROM subscriptions WHERE id = ?', [row['id']])
+      end
     end
 
     # push_token は維持する。上流に登録済みの endpoint (/push/{push_token}) が

--- a/test/legacy_row_purge_test.rb
+++ b/test/legacy_row_purge_test.rb
@@ -1,0 +1,177 @@
+require_relative 'test_helper'
+require 'fileutils'
+require 'logger'
+require 'securerandom'
+require 'sqlite3'
+require 'tmpdir'
+require 'lib/relay/database'
+
+# device_id 導入前 (capsicum#932 以前) のクライアントが残した孤児行の掃除
+# (capsicum#949 / capsicum-relay#15)。
+#
+# 旧版は push トークンが変わるたびに新しい行を作っており、その行は上流の購読が
+# 生きている限り push され続けるため **1 通の通知が行数ぶん増える**。2026-08-10 に
+# 実機で確認した例では windows 3 行 = 3 通で、行を消したら 1 通に戻った。
+#
+# 掃除は「生きている別端末を巻き込まない」ことが最重要なので、そこを厚く固定する。
+class LegacyRowPurgeTest < Minitest::Test
+  ACCOUNT = 'pooza@misskey.delmulin.com'.freeze
+  SERVER = 'misskey.delmulin.com'.freeze
+
+  def setup
+    @dir = Dir.mktmpdir('relay-legacy-purge-test')
+    @original_db_path = Relay::Database::DB_PATH
+    swap_db_path(File.join(@dir, 'relay.sqlite3'))
+    @db = Relay::Database.new(logger: Logger.new(File::NULL))
+  end
+
+  def teardown
+    swap_db_path(@original_db_path)
+    FileUtils.remove_entry(@dir)
+  end
+
+  # 本題。旧版が残した古い行は、新版が登録した時点で消える。
+  def test_stale_legacy_rows_are_purged_when_the_new_client_registers
+    legacy = insert_legacy_row('old-wns-uri-1', days_ago: 30)
+    other_legacy = insert_legacy_row('old-wns-uri-2', days_ago: 20)
+
+    @db.register(
+      token: 'new-wns-uri', device_type: 'windows',
+      account: ACCOUNT, server: SERVER, device_id: 'install-a'
+    )
+
+    assert_nil(@db.find(legacy['id']))
+    assert_nil(@db.find(other_legacy['id']))
+    assert_equal(1, rows_for('windows').length)
+  end
+
+  # 猶予内の行は残す。**同じ OS の別実機がまだ旧版で動いている**ケースを
+  # 巻き込まないための線引きで、ここが緩むと生きた端末が不達になる。
+  def test_recently_seen_legacy_rows_are_kept
+    fresh = insert_legacy_row('another-live-pc', days_ago: 3)
+
+    @db.register(
+      token: 'new-wns-uri', device_type: 'windows',
+      account: ACCOUNT, server: SERVER, device_id: 'install-a'
+    )
+
+    refute_nil(@db.find(fresh['id']))
+  end
+
+  # 端末種別が違う行は対象外。Windows の更新で Android の行を消してはいけない。
+  def test_other_device_types_are_untouched
+    android = insert_legacy_row('old-fcm-token', days_ago: 60, device_type: 'android')
+
+    @db.register(
+      token: 'new-wns-uri', device_type: 'windows',
+      account: ACCOUNT, server: SERVER, device_id: 'install-a'
+    )
+
+    refute_nil(@db.find(android['id']))
+  end
+
+  # 別アカウント / 別サーバーの行も対象外（同一端末に複数垢を載せる運用）。
+  def test_other_accounts_are_untouched
+    other = insert_legacy_row('old-uri', days_ago: 60, account: 'someone@else.example')
+
+    @db.register(
+      token: 'new-wns-uri', device_type: 'windows',
+      account: ACCOUNT, server: SERVER, device_id: 'install-a'
+    )
+
+    refute_nil(@db.find(other['id']))
+  end
+
+  # device_id 付きの行は、古くても消さない。別の実機（新版）かもしれないため。
+  def test_rows_with_device_id_are_never_purged
+    sibling = insert_legacy_row('other-install-uri', days_ago: 90, device_id: 'install-b')
+
+    @db.register(
+      token: 'new-wns-uri', device_type: 'windows',
+      account: ACCOUNT, server: SERVER, device_id: 'install-a'
+    )
+
+    refute_nil(@db.find(sibling['id']))
+  end
+
+  # 旧クライアント（device_id なし）の登録では掃除しない。掃除の前提は
+  # 「そのインストールが新版へ更新済み」なので、旧版の登録で走らせては困る。
+  def test_legacy_client_registration_does_not_purge
+    legacy = insert_legacy_row('old-uri', days_ago: 60)
+
+    @db.register(token: 'another-old-uri', device_type: 'windows', account: ACCOUNT, server: SERVER)
+
+    refute_nil(@db.find(legacy['id']))
+  end
+
+  # 自分自身を消さない。旧行を adopt して device_id を埋めた直後でも、
+  # その行が purge の対象に入ってはいけない（入ると登録のたびに消える）。
+  def test_the_row_just_registered_is_kept
+    adopted = insert_legacy_row('kept-uri', days_ago: 60)
+
+    result = @db.register(
+      token: 'kept-uri', device_type: 'windows',
+      account: ACCOUNT, server: SERVER, device_id: 'install-a'
+    )
+
+    assert_equal(adopted['id'], result['id'])
+    refute_nil(@db.find(result['id']))
+    assert_equal('install-a', result['device_id'])
+  end
+
+  # 孤児を消すと、その行にぶら下がるお知らせ購読も FK の CASCADE で消える。
+  def test_purge_cascades_to_announcement_subscriptions
+    legacy = insert_legacy_row('old-uri', days_ago: 60)
+    @db.register_announcement_subscription(
+      push_token: legacy['push_token'], server: SERVER, account: ACCOUNT,
+    )
+
+    @db.register(
+      token: 'new-wns-uri', device_type: 'windows',
+      account: ACCOUNT, server: SERVER, device_id: 'install-a'
+    )
+
+    assert_empty(@db.find_announcement_subscriptions_by_push_token(legacy['push_token']))
+  end
+
+  private
+
+  def swap_db_path(path)
+    Relay::Database.send(:remove_const, :DB_PATH)
+    Relay::Database.const_set(:DB_PATH, path)
+  end
+
+  # 旧クライアントが作ったのと同じ形の行を、更新時刻を指定して直接入れる。
+  # register 経由だと updated_at が now になり、猶予の検証ができない。
+  def insert_legacy_row(token, days_ago:, device_type: 'windows', account: ACCOUNT,
+    device_id: nil)
+    params = [token, SecureRandom.hex(32), device_type, account, SERVER, device_id,
+      days_ago, days_ago]
+    raw do |db|
+      db.execute(<<~SQL, params)
+        INSERT INTO subscriptions
+          (token, push_token, device_type, account, server, device_id, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, datetime('now', '-' || ? || ' days'),
+                datetime('now', '-' || ? || ' days'))
+      SQL
+    end
+    return raw {|db| db.execute('SELECT * FROM subscriptions WHERE token = ?', [token])}.first
+  end
+
+  def rows_for(device_type)
+    return raw do |db|
+      db.execute(
+        'SELECT * FROM subscriptions WHERE account = ? AND server = ? AND device_type = ?',
+        [ACCOUNT, SERVER, device_type],
+      )
+    end
+  end
+
+  def raw
+    db = SQLite3::Database.new(Relay::Database::DB_PATH)
+    db.results_as_hash = true
+    return yield(db)
+  ensure
+    db&.close
+  end
+end


### PR DESCRIPTION
capsicum#949 の恒久対処。main への直接 push が保護ルールで弾かれるため PR にしています。

## 実機で確認した現象

`pooza@misskey.delmulin.com` の windows 行が 3 本（7/13・7/22・8/6 作成）あり、いずれも**同じ PC の別々の WNS チャンネル URI**を指していました。1 通のメンションに対し relay のログは受信 3・送信 3 で、体感も 3 通。古い 2 行を手で消したら受信 1・送信 1 に戻り、1 通になりました。

capsicum#932 / #937 は「これから孤児を作らない」仕組みで、**既に溜まった行には効きません**。実測でこの条件に当てはまる行が **75** ありました（windows 39 / android 28 / ios 8）。

## やること

登録のたびに、同じ `(account, server, device_type)` の古い行を消します。消すのは 3 つ揃ったときだけです。

1. `device_id` が無い（＝旧版が作った行）
2. 同じ組に `device_id` 付きの行が既にある（＝そのインストールは更新済み）
3. `LEGACY_ROW_GRACE_DAYS`（14 日）以上更新されていない

3 が要るのは、**同じ OS の別実機がまだ旧版で動いている**場合を巻き込まないためです。生きている端末は起動のたびに register して `updated_at` が進むので、猶予を超えるのは実際に使われていない行だけになります。仮に巻き込んでも次の起動で再登録されるので自己修復します。

上流の購読は消せませんが、行が無くなれば `/push/{push_token}` が **410 Gone** を返し、上流がその購読を破棄します。

**専用のスイープ機構は置きません。**クライアントは起動ごとに register するので、使われているインストールから順に自然に掃除されます。既存の 75 行もこれで消えます。

## 検証

`test/legacy_row_purge_test.rb` に 8 件。巻き込み防止（猶予内 / 別端末種別 / 別アカウント / `device_id` 付き / 旧クライアントの登録では走らない / 自分自身）を厚く固定しました。relay 全 24 件緑・RuboCop clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)