### PR TITLE
feat: WNS 送信の Channel URI host allowlist と payload 事前チェックを入れる (#21)

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -262,6 +262,14 @@ module Relay
         halt 400, {error: 'device_type must be ios, android, macos or windows'}.to_json
       end
 
+      # windows の token は WNS Channel URI。任意ホストを保存すると /push で
+      # そこへ Bearer + payload 付き POST をさせられる (SSRF) ため、入口で WNS
+      # ホストに限定する (#21 / capsicum#474 レビュー)。
+      if json_body['device_type'] == 'windows' &&
+          !Relay::WnsClient.valid_channel_uri?(json_body['token'])
+        halt 400, {error: 'token must be a WNS channel URI (*.notify.windows.com)'}.to_json
+      end
+
       # device_id は任意。送ってこない旧クライアントは従来どおり token をキーに
       # 登録される (#15 / capsicum#932)。
       sub = settings.database.register(

--- a/lib/relay/wns_client.rb
+++ b/lib/relay/wns_client.rb
@@ -26,7 +26,11 @@ module Relay
   #     / client_secret=<secret> / scope=notify.windows.com
   # で OAuth アクセストークンを取得し、Channel URI への POST に Bearer で添える。
   # トークンは expires_in までキャッシュし、401 を受けたら 1 回だけ強制更新する。
-  class WnsClient
+  #
+  # OAuth・トークンキャッシュ・送信・応答解釈・#21 の入力検証まで一つの WNS 送信
+  # 単位に凝集しており、130 行を数行超える。分割すると I/F がまたぐだけなので、
+  # App / Database と同様にここは ClassLength を inline で許容する。
+  class WnsClient # rubocop:disable Metrics/ClassLength
     OAUTH_ENDPOINT = 'https://login.live.com/accesstoken.srf'.freeze
     OAUTH_SCOPE = 'notify.windows.com'.freeze
     # アクセストークン有効期限の手前で失効扱いにするマージン (秒)。
@@ -40,6 +44,31 @@ module Relay
     # WNS raw payload の上限 5000 バイト超過 (413)。subscription は健全なので
     # unregister せず、該当 1 通だけドロップする（APNs / FCM の oversized と同じ）。
     OVERSIZED_STATUS = 413
+    # WNS raw notification の payload 上限 (バイト)。aes128gcm 暗号文を base64 化
+    # したエンベロープは元 payload の約 1.4 倍に膨らみ、長い Misskey ノート等で
+    # 4KB(APNs/FCM) より先に超過しうる。現状は POST して 413 を受けてから oversized
+    # 処理する事後対応だが、送信前に弾いて WNS への無駄打ちと round-trip を省く
+    # (#21)。倒れ方は 413 経路と同一なので観測（Sentry oversized 件数）も揃う。
+    RAW_PAYLOAD_LIMIT = 5000
+    # Channel URI として許可するホストの suffix。capsicum の Windows クライアント
+    # が classic PushNotificationChannel から得る Channel URI は必ず
+    # *.notify.windows.com に載る。device_type=windows の token は /register を
+    # 通れば任意ホストへ Bearer + payload 付き POST をさせられる（SSRF）ため、
+    # 送信先を WNS ホストへ限定する (#21 / capsicum#474 レビュー)。
+    CHANNEL_URI_HOST_SUFFIX = '.notify.windows.com'.freeze
+
+    # Channel URI が https かつ WNS ホストであることを検査する。register の入口
+    # (app.rb) と push 前 (defense-in-depth) の双方から使う class method。実 URI は
+    # 必ず region 付きサブドメイン (db5p / sg2p 等) なので suffix 一致で十分、かつ
+    # notify.windows.com.evil.com のような suffix なりすましは弾ける。
+    def self.valid_channel_uri?(channel_uri)
+      uri = URI(channel_uri.to_s)
+      return false unless uri.is_a?(URI::HTTPS) && uri.host
+
+      return uri.host.downcase.end_with?(CHANNEL_URI_HOST_SUFFIX)
+    rescue URI::InvalidURIError
+      return false
+    end
 
     def initialize(config, logger: Logger.new($stdout))
       @config = config
@@ -52,7 +81,18 @@ module Relay
     end
 
     def push(device_token:, payload:)
+      # 送信先ホストが WNS でなければ POST しない (#21)。register で弾いているので
+      # 通常は起きないが、既存行や将来の抜けに対する防御。invalid は subscription
+      # を消さない（permanent: false）— 誤 unregister より観測に倒す。
+      unless self.class.valid_channel_uri?(device_token)
+        return invalid_channel_uri_result(device_token)
+      end
+
       body = payload.to_json
+      # 5000B 超過は POST せず 413 経路に倒す (#21)。事後の 413 と同じ oversized
+      # 扱いなので上位（handle_push_oversized）の挙動・観測は変わらない。
+      return oversized_precheck_result(body.bytesize) if body.bytesize > RAW_PAYLOAD_LIMIT
+
       response = post_raw(device_token, body)
       # 401 はアクセストークン失効の可能性が高い。1 回だけ強制更新して再送する
       # （毎回更新すると login.live.com を過剰に叩くため、失敗起点でのみ）。
@@ -61,6 +101,37 @@ module Relay
     end
 
     private
+
+    # push が返す失敗ハッシュの共通形。handle_push_result が success / oversized /
+    # permanent を見て分岐するので、全経路でキーを揃える。
+    def failure(status:, reason:, permanent: false, oversized: false)
+      return {
+        success: false, status: status, reason: reason,
+        permanent: permanent, oversized: oversized
+      }
+    end
+
+    # 送信前 5000B 超過。interpret の 413 応答と同型 (oversized: true) を返し、
+    # handle_push_oversized の drop + 観測にそのまま乗せる。
+    def oversized_precheck_result(size)
+      @logger.warn("WNS payload too large (pre-check): #{size} > #{RAW_PAYLOAD_LIMIT}")
+      return failure(
+        status: OVERSIZED_STATUS, reason: 'PayloadTooLarge (pre-check)', oversized: true,
+      )
+    end
+
+    # WNS 以外のホストへ向いた Channel URI。送らずに失敗として返す。permanent:
+    # false で subscription は残し、Sentry に上げて件数を観測する（想定 0 件）。
+    def invalid_channel_uri_result(channel_uri)
+      host = URI(channel_uri.to_s).host rescue nil
+      @logger.warn("WNS channel URI rejected (non-WNS host): #{host.inspect}")
+      Relay::SentrySetup.capture_message(
+        'WNS channel URI rejected (non-WNS host)',
+        level: :warning,
+        context: {wns: {host: host}},
+      )
+      return failure(status: nil, reason: 'invalid_channel_uri')
+    end
 
     def post_raw(channel_uri, body, force_token_refresh: false)
       token = access_token(force_refresh: force_token_refresh)
@@ -82,11 +153,7 @@ module Relay
     end
 
     def interpret(response)
-      unless response
-        return {
-          success: false, status: nil, reason: 'no_response', permanent: false, oversized: false
-        }
-      end
+      return failure(status: nil, reason: 'no_response') unless response
 
       status = response.code.to_i
       if response.is_a?(Net::HTTPSuccess)
@@ -96,13 +163,12 @@ module Relay
         return {success: true, status: status, wns_status: response['X-WNS-NotificationStatus']}
       end
 
-      return {
-        success: false,
+      return failure(
         status: status,
         reason: response['X-WNS-Error-Description'] || response['X-WNS-Status'] || response.message,
         permanent: PERMANENT_STATUSES.include?(status),
         oversized: status == OVERSIZED_STATUS,
-      }
+      )
     end
 
     def access_token(force_refresh: false)

--- a/test/wns_client_test.rb
+++ b/test/wns_client_test.rb
@@ -1,0 +1,71 @@
+require_relative 'test_helper'
+require 'logger'
+require 'lib/relay/wns_client'
+
+# #21: WNS Channel URI の host allowlist と送信前の payload サイズチェック。
+# いずれも「送る前に弾く」ロジックなので、OAuth / ネットワークに触れずに検査
+# できる（短絡した時点で post_raw も access_token も呼ばれない）。
+class WnsClientTest < Minitest::Test
+  CONFIG = {'wns' => {'package_sid' => 'sid', 'client_secret' => 'secret'}}.freeze
+  VALID_URI = 'https://db5p.notify.windows.com/w/?token=abc'.freeze
+
+  # --- valid_channel_uri? (SSRF allowlist) -----------------------------------
+
+  def test_accepts_wns_channel_uri
+    assert(Relay::WnsClient.valid_channel_uri?(VALID_URI))
+    assert(Relay::WnsClient.valid_channel_uri?('https://sg2p.notify.windows.com/?x=1'))
+  end
+
+  # region 付きサブドメインが実 URI の形。bare host は実在しないので弾いてよい。
+  def test_rejects_bare_wns_host
+    refute(Relay::WnsClient.valid_channel_uri?('https://notify.windows.com/w/'))
+  end
+
+  def test_rejects_non_wns_host
+    refute(Relay::WnsClient.valid_channel_uri?('https://evil.example.com/w/'))
+  end
+
+  # notify.windows.com.evil.com のような suffix なりすましを弾く。
+  def test_rejects_lookalike_host
+    refute(Relay::WnsClient.valid_channel_uri?('https://notify.windows.com.evil.com/w/'))
+  end
+
+  def test_rejects_plain_http
+    refute(Relay::WnsClient.valid_channel_uri?('http://db5p.notify.windows.com/w/'))
+  end
+
+  def test_rejects_blank_and_garbage
+    refute(Relay::WnsClient.valid_channel_uri?(nil))
+    refute(Relay::WnsClient.valid_channel_uri?(''))
+    refute(Relay::WnsClient.valid_channel_uri?('not a uri'))
+  end
+
+  # --- push pre-checks（ネットワーク非依存で短絡すること） --------------------
+
+  def test_push_rejects_invalid_channel_uri_without_network
+    client = build_client
+    result = client.push(device_token: 'https://evil.example.com/x', payload: {'a' => 1})
+
+    refute(result[:success])
+    assert_equal('invalid_channel_uri', result[:reason])
+    refute(result[:permanent])
+    refute(result[:oversized])
+  end
+
+  def test_push_rejects_oversized_payload_before_sending
+    client = build_client
+    payload = {'body' => 'x' * (Relay::WnsClient::RAW_PAYLOAD_LIMIT + 1)}
+    result = client.push(device_token: VALID_URI, payload: payload)
+
+    refute(result[:success])
+    assert_equal(Relay::WnsClient::OVERSIZED_STATUS, result[:status])
+    assert(result[:oversized])
+    refute(result[:permanent])
+  end
+
+  private
+
+  def build_client
+    return Relay::WnsClient.new(CONFIG, logger: Logger.new(File::NULL))
+  end
+end


### PR DESCRIPTION
Closes #21

capsicum#474 のリリース前レビュー指摘。いずれも認証・413 フォールバックで緩和済みの非ブロッカーだが堅牢化する。

## WNS Channel URI の host allowlist（SSRF 緩和）
`device_type=windows` の `token` は WNS Channel URI だが、`/register`（shared_secret 認証）を通れば任意ホストへ Bearer + payload 付き POST をさせられた。

- `Relay::WnsClient.valid_channel_uri?` を追加（https かつ host が `.notify.windows.com` suffix）。
- register 入口（`app.rb`）で不正な windows token を 400 で弾く。
- `WnsClient#push` でも送信前に再検査（defense-in-depth。既存行や将来の抜けに対する保険。permanent: false で subscription は消さず Sentry 観測）。
- `notify.windows.com.evil.com` のような suffix なりすまし・平文 `http` も拒否。

## WNS raw payload の送信前サイズチェック
現状は POST して 413 を受けてから oversized 処理する事後対応のみ。5000B 超過を送信前に検査し、超過は POST せず 413 経路（oversized）へ倒す。事後 413 と同型の失敗を返すので `handle_push_oversized` の drop・Sentry 観測はそのまま。WNS への無駄打ちと round-trip を省く。

## その他
- 失敗ハッシュ生成を `failure` ヘルパへ寄せ、`interpret` とも共通化。
- `test/wns_client_test.rb` を新設し、allowlist 判定と 2 つの事前チェック短絡（ネットワーク非依存）を固定。
- `bundle exec rake test` green / `bundle exec rubocop` offense なし。