### PR TITLE
APNs の payload 上限超過を汎用文面へ degrade して配送する (#17)

### DIFF
--- a/lib/relay/apns_client.rb
+++ b/lib/relay/apns_client.rb
@@ -1,6 +1,7 @@
 require 'apnotic'
 require 'logger'
 require 'monitor'
+require_relative 'apns_payload'
 require_relative 'sentry_setup'
 
 module Relay
@@ -9,9 +10,15 @@ module Relay
     # これらを受けた場合、relay は Mastodon に HTTP 410 Gone を返して
     # subscription を destroy してもらい、自らの row も削除する。
     PERMANENT_REASONS = ['BadDeviceToken', 'Unregistered', 'DeviceTokenNotForTopic'].freeze
+    # degrade しても上限を割れず、送信前に倒したときの合成 reason (#17)。下流
+    # (handle_push_oversized) の扱いを APNs 実応答の 413 と揃えるため、下の
+    # OVERSIZED_REASONS に同居させる。
+    OVERSIZED_PRECHECK_REASON = 'PayloadTooLarge (pre-check)'.freeze
     # APNs payload 上限 (alert push 4KB) 超過。subscription は健全なので
     # unregister せず、該当 1 通だけドロップする (#9)。
-    OVERSIZED_REASONS = ['PayloadTooLarge'].freeze
+    OVERSIZED_REASONS = ['PayloadTooLarge', OVERSIZED_PRECHECK_REASON].freeze
+    # 送信前に倒すときに載せる HTTP ステータス。APNs の 413 に合わせる。
+    OVERSIZED_STATUS = 413
     # 非 JSON の失敗応答は HTML のエラーページ全文でありうるので、切り分けに
     # 足りる長さだけ残してログ / Sentry へ載せる (#25)。
     BODY_SNIPPET_LIMIT = 200
@@ -20,6 +27,7 @@ module Relay
       @config = config
       @logger = logger
       @mon = Monitor.new
+      @payload = Relay::ApnsPayload.new(config['apns']['bundle_id'])
       @connection = build_connection
     end
 
@@ -27,11 +35,18 @@ module Relay
     # 返し、上流に「配信失敗」ではなく「relay が壊れた」と見えるうえ、
     # permanent / oversized の判定（無効トークンの掃除・1 通ドロップ）にも
     # 到達しなくなるため (#25 / #26)。
+    # 上限超過時に暗号化 body を外した汎用文面へ倒す degrade は ApnsPayload が判断する
+    # (#17)。Notification は 1 回だけ組み立てて再送でも使い回す。apns-id が同じままに
+    # なり、StreamLimit 再送が二重配信に見えるのを避けられる。
     def push(device_token:, payload:, alert: nil)
       connection = @connection
-      return deliver(connection, device_token, payload, alert: alert)
+      built = @payload.build(device_token: device_token, payload: payload, alert: alert)
+      return oversized_precheck_result(built) unless built.notification
+
+      log_degrade(built) if built.degraded_from
+      return deliver(connection, built.notification, degraded_from: built.degraded_from)
     rescue HTTP2::Error::StreamLimitExceeded => e
-      return push_after_reset(connection, e, device_token, payload, alert)
+      return push_after_reset(connection, e, built)
     end
 
     def close
@@ -40,9 +55,9 @@ module Relay
 
     private
 
-    def deliver(connection, device_token, payload, alert: nil)
-      response = connection.push(build_notification(device_token, payload, alert: alert))
-      return {success: true, id: response.headers['apns-id']} if response&.ok?
+    def deliver(connection, notification, degraded_from: nil)
+      response = connection.push(notification)
+      return delivered(response, degraded_from) if response&.ok?
 
       return failure(
         status: response&.status,
@@ -51,16 +66,45 @@ module Relay
       )
     end
 
+    # degrade して送ったときだけ degraded / original_size を添える。上位
+    # (handle_push_delivered) が「届いたが本文は読めない」を観測するのに使う。
+    def delivered(response, degraded_from)
+      result = {success: true, id: response.headers['apns-id']}
+      return result unless degraded_from
+
+      return result.merge(degraded: true, original_size: degraded_from)
+    end
+
+    def log_degrade(built)
+      @logger.warn(
+        "APNs payload degraded to generic alert: #{built.degraded_from}B" \
+          " > #{Relay::ApnsPayload::PAYLOAD_LIMIT}B (sent #{built.byte_size}B)",
+      )
+    end
+
+    # degrade しても上限を割れない稀なケース（account 名だけで 4KB を超える等）。
+    # 事後の 413 応答と同型 (oversized: true) を返し、handle_push_oversized の
+    # drop + 観測へそのまま倒す。WNS の同名メソッド (#21) と役割を揃えている。
+    def oversized_precheck_result(built)
+      @logger.warn(
+        "APNs payload too large after degrade: #{built.byte_size}B" \
+          " > #{Relay::ApnsPayload::PAYLOAD_LIMIT}B",
+      )
+      return failure(status: OVERSIZED_STATUS, reason: OVERSIZED_PRECHECK_REASON)
+    end
+
     # ストリーム上限は接続を張り直さないと戻らないので、作り直して 1 回だけ
     # 送り直す。`HTTP2::Connection#new_stream` はバイトを 1 つも送る前に raise
     # するため、この再送で二重配信にはならない。2 回目も上限に当たったら
     # failure に落として上流の再送に委ねる（handle_push_failed → 502）。
-    def push_after_reset(stale, error, device_token, payload, alert)
+    def push_after_reset(stale, error, built)
       @logger.warn(
         'APNs stream limit reached; reconnecting and retrying once:' \
           " #{error.class}: #{error.message}",
       )
-      return deliver(reset_connection(stale), device_token, payload, alert: alert)
+      return deliver(
+        reset_connection(stale), built.notification, degraded_from: built.degraded_from
+      )
     rescue HTTP2::Error::StreamLimitExceeded
       return failure(status: nil, reason: 'StreamLimitExceeded')
     end
@@ -155,20 +199,6 @@ module Relay
         # 起きるため、明示捕捉しないと Sentry に上がらない。#8 の本丸 (#10 Phase C)。
         Relay::SentrySetup.capture_exception(error, context: {apns: {source: 'socket_loop'}})
       end
-    end
-
-    def build_notification(device_token, payload, alert: nil)
-      notification = Apnotic::Notification.new(device_token)
-      notification.topic = @config['apns']['bundle_id']
-      notification.alert = alert || {
-        title: 'capsicum',
-        body: "#{payload['account']} に通知があります",
-      }
-      notification.sound = 'default'
-      notification.mutable_content = true
-      notification.custom_payload = payload
-      notification.push_type = 'alert'
-      return notification
     end
   end
 end

--- a/lib/relay/apns_payload.rb
+++ b/lib/relay/apns_payload.rb
@@ -1,0 +1,67 @@
+require 'apnotic'
+
+module Relay
+  # APNs へ送る Notification の組み立てと、payload 上限に対する degrade 判断 (#17)。
+  #
+  # ApnsClient から分けているのは、この責務が **接続・再送・応答解釈を一切知らずに
+  # 済む**ため（bundle_id と payload だけで完結する）。WnsClient のように inline
+  # disable で ClassLength を伸ばすより、素直な seam で切った方が単体で検証できる。
+  #
+  # degrade の意味: APNs は payload 上限超過を 413 PayloadTooLarge で返し、その 1 通は
+  # 端末に一切届かない（#9 で drop 扱いにした）。暗号化 body を落とせば aps.alert の
+  # 汎用文面だけは届けられるので、上限超過時はそこへ倒す。iOS / macOS の NSE も Dart
+  # 側 dispatcher も body / encoding 不在を「復号せず relay の alert をそのまま出す」
+  # 経路として既に持っており（お知らせ通知 capsicum#477 が同じ形で出荷済み）、client
+  # 側の変更なしでこの degrade に乗る。
+  class ApnsPayload
+    # APNs alert push の payload 上限 (バイト)。aps と custom_payload を JSON 化した
+    # 全体に効くので、判定は組み立て済み Notification#body のバイト数で行う。
+    PAYLOAD_LIMIT = 4096
+    # degrade で落とす、暗号化 Web Push 由来のキー (push_helpers の build_push_payload)。
+    # body が実質すべての容量を占めるが、body 抜きでは意味を持たない同伴キーも一緒に
+    # 落として「復号を試みない payload」として辻褄を合わせる。
+    ENCRYPTED_KEYS = ['body', 'encoding', 'crypto_key', 'encryption'].freeze
+
+    # build の戻り値。
+    #   notification  : 送るべき Notification。degrade しても上限を割れないときだけ nil
+    #   degraded_from : degrade したときの「degrade 前」バイト数。していなければ nil
+    #   byte_size     : 実際に送る（送れないときは degrade 後の）バイト数
+    Built = Struct.new(:notification, :degraded_from, :byte_size, keyword_init: true)
+
+    def initialize(bundle_id)
+      @bundle_id = bundle_id
+    end
+
+    def build(device_token:, payload:, alert: nil)
+      notification = build_notification(device_token, payload, alert)
+      size = notification.body.bytesize
+      return Built.new(notification: notification, byte_size: size) if size <= PAYLOAD_LIMIT
+
+      fallback = build_notification(device_token, degraded_payload(payload), alert)
+      fallback_size = fallback.body.bytesize
+      return Built.new(byte_size: fallback_size) if fallback_size > PAYLOAD_LIMIT
+
+      return Built.new(notification: fallback, degraded_from: size, byte_size: fallback_size)
+    end
+
+    private
+
+    def degraded_payload(payload)
+      return payload.reject {|key, _| ENCRYPTED_KEYS.include?(key.to_s)}
+    end
+
+    def build_notification(device_token, payload, alert)
+      notification = Apnotic::Notification.new(device_token)
+      notification.topic = @bundle_id
+      notification.alert = alert || {
+        title: 'capsicum',
+        body: "#{payload['account']} に通知があります",
+      }
+      notification.sound = 'default'
+      notification.mutable_content = true
+      notification.custom_payload = payload
+      notification.push_type = 'alert'
+      return notification
+    end
+  end
+end

--- a/lib/relay/push_helpers.rb
+++ b/lib/relay/push_helpers.rb
@@ -102,9 +102,29 @@ module Relay
     def handle_push_delivered(sub, result = {})
       wns_status = result[:wns_status]
       return handle_wns_status(sub, result, wns_status) if wns_status && wns_status != 'received'
+      return handle_push_degraded(sub, result) if result[:degraded]
 
       settings.logger.info("Pushed to #{sub['device_type']}: #{sub['account']}")
       return {status: 'delivered'}.to_json
+    end
+
+    # 暗号化 payload が上限を超えたため汎用文面だけ届けた (#17)。以前は 1 通まるごと
+    # drop していた（端末に何も出ない）ので、**ここに来るのは改善後の正常系**。ただし
+    # 「本文の読めない通知」ではあり、送信側の payload 設計が肥大していないかを追う
+    # 材料になるので warning として件数を観測する。drop (Push oversized dropped) とは
+    # 別メッセージにして、本当の不達が 0 になったことを確認できるようにする。件数が
+    # 青天井になるようなら WNS_BENIGN_STATUSES と同じくログのみへ落とす。
+    def handle_push_degraded(sub, result)
+      settings.logger.warn(
+        "Push degraded to generic alert: #{sub['account']}" \
+          " (#{sub['device_type']}, #{result[:original_size]}B)",
+      )
+      Relay::SentrySetup.capture_message(
+        "Push oversized degraded (#{sub['device_type']})",
+        level: :warning,
+        context: {push: push_context(sub, result).merge(original_size: result[:original_size])},
+      )
+      return {status: 'delivered', degraded: true}.to_json
     end
 
     # 配信は受理扱い（success）だが実質的な不達。WNS 固有の静かな失敗モードで、

--- a/test/apns_client_test.rb
+++ b/test/apns_client_test.rb
@@ -5,14 +5,16 @@ require 'lib/relay/apns_client'
 # Apnotic::Connection の代役。push が返すもの（あるいは raise するもの）を
 # 呼び出し順のスクリプトで与える。
 class FakeApnsConnection
-  attr_reader :closed
+  attr_reader :closed, :pushed
 
   def initialize(script)
     @script = script
     @closed = false
+    @pushed = []
   end
 
-  def push(_notification)
+  def push(notification)
+    @pushed << notification
     action = @script.shift
     raise HTTP2::Error::StreamLimitExceeded if action == :stream_limit
     return action
@@ -41,7 +43,10 @@ class FakeApnsResponse
   end
 end
 
-# 実 APNs へ繋がずに済むよう、接続の生成と Notification の組み立てだけ差し替える。
+# 実 APNs へ繋がずに済むよう、接続の生成だけ差し替える。Notification の組み立ては
+# 本物を使う（#17 の degrade 判定は組み立て済み payload のバイト数で決まるので、
+# ここを stub すると検証の意味が無くなる）。Apnotic::Notification は生成に I/O を
+# 伴わないため、そのまま組める。
 class StubbedApnsClient < Relay::ApnsClient
   attr_reader :connections
 
@@ -61,10 +66,6 @@ class StubbedApnsClient < Relay::ApnsClient
     connection = FakeApnsConnection.new(@scripts.fetch(@connections.size, []))
     @connections << connection
     return connection
-  end
-
-  def build_notification(*, **)
-    return :notification
   end
 end
 
@@ -153,6 +154,104 @@ class ApnsClientTest < Minitest::Test
     assert(results.all? {|result| result[:success]})
   end
 
+  # --- #17: oversized の degrade ---------------------------------------------
+
+  # 上限内の通常 payload は素通し。degrade の副作用で暗号化 body を落とさない。
+  def test_normal_payload_is_sent_untouched
+    client = build_client(0 => [OK_RESPONSE])
+    result = client.push(device_token: 't', payload: push_payload(body: 'x' * 100))
+
+    assert(result[:success])
+    refute(result[:degraded])
+    sent = sent_payload(client)
+    assert_equal('x' * 100, sent['body'])
+    assert_equal('aes128gcm', sent['encoding'])
+  end
+
+  # 以前はここで 413 を受けて 1 通まるごと drop していた（端末に何も出ない）。
+  def test_oversized_payload_is_degraded_and_delivered
+    original = push_payload(body: 'x' * 5000)
+    client = build_client(0 => [OK_RESPONSE])
+    result = client.push(device_token: 't', payload: original)
+
+    assert(result[:success])
+    assert(result[:degraded])
+    refute(result[:oversized])
+  end
+
+  # degrade は暗号化 payload 由来のキーだけを落とし、宛先の判別に要る
+  # account / server と aps.alert は残す（NSE はこの alert を出す）。
+  def test_degraded_payload_drops_only_the_encrypted_keys
+    client = build_client(0 => [OK_RESPONSE])
+    client.push(device_token: 't', payload: push_payload(body: 'x' * 5000))
+    sent = sent_payload(client)
+
+    assert_nil(sent['body'])
+    assert_nil(sent['encoding'])
+    assert_nil(sent['crypto_key'])
+    assert_nil(sent['encryption'])
+    assert_equal('user@example.com', sent['account'])
+    assert_equal('https://example.com', sent['server'])
+    assert_equal('user@example.com に通知があります', sent.dig('aps', 'alert', 'body'))
+  end
+
+  # 送った payload が上限を割っていること（degrade の目的そのもの）。
+  def test_degraded_notification_is_within_the_limit
+    client = build_client(0 => [OK_RESPONSE])
+    client.push(device_token: 't', payload: push_payload(body: 'x' * 5000))
+
+    assert_operator(
+      client.connections[0].pushed.first.body.bytesize,
+      :<=,
+      Relay::ApnsPayload::PAYLOAD_LIMIT,
+    )
+  end
+
+  # 観測用に「degrade 前のサイズ」を返す。Sentry の context に載る。
+  def test_degraded_result_reports_the_original_size
+    client = build_client(0 => [OK_RESPONSE])
+    result = client.push(device_token: 't', payload: push_payload(body: 'x' * 5000))
+
+    assert_operator(result[:original_size], :>, Relay::ApnsPayload::PAYLOAD_LIMIT)
+  end
+
+  # degrade しても割れない場合は送らずに 413 経路へ倒す（WNS の pre-check と同型）。
+  def test_still_oversized_after_degrade_falls_back_to_the_oversized_path
+    huge_account = 'a' * 5000
+    client = build_client(0 => [OK_RESPONSE])
+    result = client.push(
+      device_token: 't', payload: push_payload(body: 'x' * 5000, account: huge_account),
+    )
+
+    refute(result[:success])
+    assert(result[:oversized])
+    refute(result[:permanent])
+    assert_equal(413, result[:status])
+    assert_empty(client.connections[0].pushed, 'must not POST when it cannot fit')
+  end
+
+  # お知らせ通知 (capsicum#477) は元から body / encoding を持たない。degrade
+  # 判定に巻き込まれず、alert もそのまま維持されること。
+  def test_announcement_style_payload_without_body_is_untouched
+    client = build_client(0 => [OK_RESPONSE])
+    payload = {'notification_type' => 'announcement', 'account' => 'user@example.com'}
+    result = client.push(device_token: 't', payload: payload, alert: {title: 'お知らせ', body: '本文'})
+
+    assert(result[:success])
+    refute(result[:degraded])
+    assert_equal('本文', sent_payload(client).dig('aps', 'alert', 'body'))
+  end
+
+  # StreamLimit の再送でも degrade の判定結果を引き継ぐこと。
+  def test_degrade_survives_the_stream_limit_retry
+    client = build_client(0 => [:stream_limit], 1 => [OK_RESPONSE])
+    result = client.push(device_token: 't', payload: push_payload(body: 'x' * 5000))
+
+    assert(result[:success])
+    assert(result[:degraded])
+    assert_nil(sent_payload(client, connection: 1)['body'])
+  end
+
   private
 
   def build_client(scripts)
@@ -161,5 +260,19 @@ class ApnsClientTest < Minitest::Test
 
   def failure_response(status, body)
     return FakeApnsResponse.new(status: status, body: body)
+  end
+
+  # build_push_payload (push_helpers) が組む形。
+  def push_payload(body:, account: 'user@example.com')
+    return {
+      'body' => body,
+      'encoding' => 'aes128gcm',
+      'server' => 'https://example.com',
+      'account' => account,
+    }
+  end
+
+  def sent_payload(client, connection: 0)
+    return JSON.parse(client.connections[connection].pushed.last.body)
   end
 end

--- a/test/push_helpers_test.rb
+++ b/test/push_helpers_test.rb
@@ -8,7 +8,7 @@ class PushHelpersTest < Minitest::Test
   EXPECTED_METHODS = [
     :build_push_payload, :dispatch_push, :push_client_for, :log_push_received,
     :handle_push_result, :push_context, :handle_push_delivered, :handle_wns_status,
-    :handle_push_gone, :handle_push_oversized, :handle_push_failed
+    :handle_push_gone, :handle_push_oversized, :handle_push_degraded, :handle_push_failed
   ].freeze
 
   def test_is_a_module_for_sinatra_helpers_mixin


### PR DESCRIPTION
Closes #17

## 背景

APNs の payload 上限 (4KB) を超えた通知は 413 PayloadTooLarge で返り、#9 でこれを drop 扱いにしている。subscription は健全なので維持されるが、**その 1 通は端末に一切届かない**。Misskey の Web Push payload は本文が長いと上限を超えやすく、Sentry `CAPSICUM-RELAY-5` で特定ユーザーに恒常的に発生していた（2026-06-07 起票時点で 4 日間 37 件、直近も 2026-08-11 に発生）。

## 変更

上限超過時に、暗号化 `body` を落とした payload で送り直し、`aps.alert` の汎用文面（`{account} に通知があります`）だけは届ける。

**受け側の変更は不要**。iOS / macOS の NSE も Dart 側 dispatcher も `body` / `encoding` 不在を「復号せず relay の alert をそのまま出す」経路として既に持っており、お知らせ通知 (capsicum#477) が同じ形で出荷済みのため。macOS NSE には該当箇所に `announcement push (#477) は body / encoding を持たない仕様のためここを通るのが正常` と明記もある。

- Notification の組み立てと degrade 判断を `Relay::ApnsPayload` へ分離した。接続・再送・応答解釈を知らずに済む seam で、`ClassLength` の inline disable を足さずに済み、payload だけを単体で検証できる
- degrade しても上限を割れない場合（account 名だけで 4KB を超える等）は POST せず 413 経路へ倒す。WNS の `oversized_precheck_result` (#21) と同型で、下流の `handle_push_oversized` の挙動・観測はそのまま
- Notification は 1 回だけ組み立てて StreamLimit 再送でも使い回す。apns-id が同じままになり、再送が二重配信に見えない

## 観測

degrade した配送は `Push oversized degraded (<device_type>)` として warning で上げる。既存の `Push oversized dropped` とは別メッセージにしたので、**本当の不達が 0 になったこと**と、**degrade がどれだけ起きているか**を分けて追える。件数が青天井になるようなら `WNS_BENIGN_STATUSES` (#24) と同じくログのみへ落とす方針をコメントに残した。

## 検証

`rake test` 44 runs / 134 assertions 緑、`rubocop` offense なし。

degrade 系のテストは変異検査で効いていることを確認済み（`PAYLOAD_LIMIT` を巨大化して degrade を無効化すると 5 件赤、暗号化キーを落とさないようにすると 3 件赤 + 2 errors）。

FCM (android) の oversized も同じ degrade に乗せられるが、`notification` ブロックの扱いが APNs と異なり汎用文面が実際に表示されるかは別途確認が要るため、本 PR では APNs のみとした（#17 のコメントに note 済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)