### PR TITLE
feat: お知らせ通知を macOS へも配送する (#36 Phase 1)

### DIFF
--- a/lib/relay/announcement_worker.rb
+++ b/lib/relay/announcement_worker.rb
@@ -122,10 +122,24 @@ module Relay
       end
     end
 
+    # device_type ごとの配送先。分岐は通常の push 経路
+    # ([Relay::PushHelpers#push_client_for]) と**同じ形に揃える**（#36）。
+    #
+    # `macos` は iOS と同一 Bundle ID・同一 APNs Auth Key で送れるので、同じ
+    # クライアントに流すだけでよい (capsicum#468)。**capsicum 側の変更は不要**:
+    # iOS/macOS の Notification Service Extension は `body` / `encoding` を
+    # 持たない push を早期 guard で素通しし、ここで付ける `aps.alert` が
+    # そのまま表示される（#17 で実測済みの挙動）。
+    #
+    # ⚠ **`windows` はまだ足さない**（Phase 2）。WNS raw push には `aps.alert`
+    # に相当する OS 側の表示機構が無く、capsicum の bg task は Web Push の
+    # 暗号化ペイロードしか解釈しない（無暗号化は `bgtask.not_encrypted` で
+    # 捨てる）。ここだけ足しても **Windows では黙って捨てられる**ので、
+    # capsicum#978 が入ってから対にする。
     def deliver(sub:, payload:, alert:)
       enriched = payload.merge('account' => sub['account'])
       case sub['device_type']
-      when 'ios'
+      when 'ios', 'macos'
         return unless @apns
 
         @apns.push(device_token: sub['token'], payload: enriched, alert: alert)

--- a/test/announcement_worker_test.rb
+++ b/test/announcement_worker_test.rb
@@ -1,0 +1,115 @@
+require_relative 'test_helper'
+require 'logger'
+require 'lib/relay/announcement_worker'
+
+# #36 Phase 1: お知らせ通知の配送先を macOS へ広げる。
+#
+# `deliver` の分岐は通常の push 経路（`Relay::PushHelpers#push_client_for`）と
+# **同じ形でなければならない**。register は 4 種すべてを受け付け、
+# `announcement_subscriptions_for_server` も device_type / token を返すので、
+# ここが揃っていないぶんだけ「登録できるのに届かない」端末が生まれる。
+#
+# ⚠ **windows をまだ足していないのは意図的**（Phase 2）。relay 側だけ足すと
+# capsicum の bg task が無暗号化ペイロードを捨てるので、**送っても黙って
+# 消える**。それを「未実装」でなく「壊れている」に見せないよう、ここで
+# 「送らない」ことを固定する。
+class AnnouncementWorkerTest < Minitest::Test
+  # push された引数を記録するだけのクライアント。
+  class RecordingClient
+    attr_reader :pushes
+
+    def initialize
+      @pushes = []
+    end
+
+    def push(**kwargs)
+      @pushes << kwargs
+      return true
+    end
+  end
+
+  def setup
+    @apns = RecordingClient.new
+    @fcm = RecordingClient.new
+    @worker = Relay::AnnouncementWorker.new(
+      database: nil,
+      logger: Logger.new(IO::NULL),
+      apns: @apns,
+      fcm: @fcm,
+    )
+  end
+
+  def deliver(device_type, token: 'tok')
+    @worker.send(
+      :deliver,
+      sub: {'device_type' => device_type, 'token' => token, 'account' => 'alice@example'},
+      payload: {'notification_type' => 'announcement'},
+      alert: {title: 'お知らせ', body: '本文'},
+    )
+  end
+
+  def test_ios_goes_to_apns
+    deliver('ios')
+
+    assert_equal(1, @apns.pushes.size)
+    assert_empty(@fcm.pushes)
+  end
+
+  # Phase 1 の本体。iOS と同一 APNs クライアントで送れる (capsicum#468)。
+  def test_macos_goes_to_apns
+    deliver('macos')
+
+    assert_equal(1, @apns.pushes.size)
+    assert_empty(@fcm.pushes)
+  end
+
+  # macOS の NSE は `aps.alert` をそのまま出すので、alert を落とすと無音になる。
+  def test_macos_carries_alert
+    deliver('macos')
+
+    assert_equal({title: 'お知らせ', body: '本文'}, @apns.pushes.first[:alert])
+  end
+
+  def test_android_goes_to_fcm
+    deliver('android')
+
+    assert_equal(1, @fcm.pushes.size)
+    assert_empty(@apns.pushes)
+  end
+
+  # ⚠ Phase 2 待ち。capsicum#978 が入るまでは送らないのが正しい。
+  def test_windows_is_not_delivered_yet
+    deliver('windows')
+
+    assert_empty(@apns.pushes)
+    assert_empty(@fcm.pushes)
+  end
+
+  def test_unknown_device_type_is_ignored
+    deliver('symbian')
+
+    assert_empty(@apns.pushes)
+    assert_empty(@fcm.pushes)
+  end
+
+  # account は payload へ混ぜて送る（capsicum 側が宛先アカウントを解決する）。
+  def test_account_is_merged_into_payload
+    deliver('macos')
+
+    assert_equal('alice@example', @apns.pushes.first[:payload]['account'])
+    assert_equal('announcement', @apns.pushes.first[:payload]['notification_type'])
+  end
+
+  # クライアント未設定（設定漏れ・起動順）でも落とさない。
+  def test_missing_client_is_survived
+    worker = Relay::AnnouncementWorker.new(
+      database: nil, logger: Logger.new(IO::NULL), apns: nil, fcm: nil,
+    )
+
+    worker.send(
+      :deliver,
+      sub: {'device_type' => 'macos', 'token' => 'tok', 'account' => 'a@b'},
+      payload: {}, alert: {},
+    )
+  end
+end


### PR DESCRIPTION
#36 の Phase 1。capsicum#919（デスクトップでもアプリ終了中にお知らせ通知を受け取れるようにする）の relay 側です。

## 何が落ちていたか

`AnnouncementWorker#deliver` が `ios` と `android` にしか配っておらず、**macOS では登録できるのに届かない**状態でした。

- register (`/subscriptions`) は `['ios', 'android', 'macos', 'windows']` を受け付ける
- `announcement_subscriptions_for_server` は `subscriptions` を JOIN して `device_type` / `token` を返す
- `Relay::PushHelpers#push_client_for` は 4 種すべてを解決できる

落ちていたのは worker の `case` だけです。

## 直し方

分岐を `push_client_for` と同じ形へ揃え、`when 'ios', 'macos'` にしました。macOS は iOS と同一 Bundle ID・同一 APNs Auth Key で送れます (capsicum#468)。

**capsicum 側の変更は不要です。** iOS/macOS の Notification Service Extension は `body` / `encoding` を持たない push を早期 guard で素通しし、ここで付ける `aps.alert` がそのまま表示されます（#17 で実測済みの挙動）。`build_alert` は `title: 'お知らせ'` + 本文プレビューを常に付けているので、そのまま出ます。

## ⚠ windows は足していません（Phase 2）

WNS raw push には `aps.alert` に相当する OS 側の表示機構が無く、capsicum の bg task は Web Push の暗号化ペイロードしか解釈しません（無暗号化は `bgtask.not_encrypted` で捨てる）。**ここだけ足しても Windows では黙って捨てられる**ので、capsicum#978 が入ってから対にします。

テストでも「windows は送られない」ことを明示的に固定しました。Phase 2 で**外すべき制約**であることを、消し忘れようのない形で残すためです。

## テスト

`test/announcement_worker_test.rb` を追加（8 ケース）。device_type ごとの配送先、alert の同伴、account の payload マージ、クライアント未設定時に落ちないことを見ています。

```
8 runs, 20 assertions, 0 failures, 0 errors, 0 skips
```

⚠ このリポジトリには CI が無いのでローカル実行です。`database` / `legacy_row_purge` / `push_helpers` / `wns_client` も通しました。**`apns_client_test.rb` だけは実行できていません**が、これは手元の system ruby が 2.6 で当該ファイルを構文解析できないためで、**この変更の前後どちらでも同じ**（stash して確認済み）です。本番は Ruby 4.0 系なので影響ありません。

## マージ後

flauros へのデプロイまで進めます（委任範囲）。**マージ＋デプロイの時点で macOS ユーザーにお知らせ通知が届き始めます。**
