### PR TITLE
feat: /health に稼働中の commit revision を出す (#37)

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -9,6 +9,7 @@ require_relative 'lib/relay/wns_client'
 require_relative 'lib/relay/announcement_worker'
 require_relative 'lib/relay/push_dedup'
 require_relative 'lib/relay/push_helpers'
+require_relative 'lib/relay/revision'
 require_relative 'lib/relay/sentry_setup'
 
 Relay::SentrySetup.init!
@@ -85,9 +86,13 @@ module Relay
     end
 
     # Health check
+    # 監視と、デプロイ差分の確認 (#37) の入口。`revision` は Sentry の release と
+    # 同じ文字列（[Relay::Revision]）なので、変換せずに突き合わせられる。
+    # 名乗れないときは null（git チェックアウト外での実行等）。
     get '/health' do
       {
         status: 'ok',
+        revision: Relay::Revision.current,
         subscriptions: settings.database.count,
         announcement_subscriptions: settings.database.announcement_subscription_count,
         supporters: settings.database.supporter_count,

--- a/lib/relay/revision.rb
+++ b/lib/relay/revision.rb
@@ -1,0 +1,52 @@
+module Relay
+  # 稼働中のコードを名乗る commit SHA (#37)。
+  #
+  # relay は **main への merge がそのまま本番の単位**で、capsicum のリリースとは
+  # 独立に進む（マイルストーン名だけ揃えている）。したがって「1.57.0」のような
+  # 版を名乗らせても実際に動いているコードと 1 対 1 で対応しないため、名乗るのは
+  # SHA にする。
+  #
+  # ⚠ **Sentry の release と `/health` の revision は同じ文字列**にする。変換なしで
+  # 突き合わせられることがこの値の主用途（「本番が古いままでは？」を SSH せずに
+  # 排除する / Sentry の release 別グラフと突き合わせる）。取得ロジックがここに 1 本
+  # しかないのはそのため。
+  module Revision
+    # デプロイ時に固定したい場合の env。git チェックアウトを持たない配置
+    # （アーカイブ展開等）でもここを設定すれば名乗れる。
+    ENV_KEY = 'SENTRY_RELEASE'.freeze
+
+    # 解決済みの SHA。取得できなければ nil。
+    #
+    # プロセスが生きている間 revision は変わらない（デプロイは再起動を伴う）ので
+    # 1 度だけ解決して覚える。`/health` は監視から定期的に叩かれるため、毎回
+    # `git rev-parse` を fork すると素直に無駄。
+    def self.current
+      return @current if defined?(@current)
+
+      @current = resolve
+    end
+
+    # テストからメモ化を捨てるための入口。
+    def self.reset!
+      remove_instance_variable(:@current) if defined?(@current)
+    end
+
+    # env 優先 → git フォールバックの順。[head] はテスト用の注入点で、
+    # 省略時は実際に `git rev-parse HEAD` を叩く。
+    def self.resolve(env: ENV, head: nil)
+      explicit = env[ENV_KEY].to_s.strip
+      return explicit unless explicit.empty?
+
+      sha = (head || git_head).to_s.strip
+      return sha.empty? ? nil : sha
+    end
+
+    # git チェックアウト外・git 未導入でも落ちない。名乗れないことは異常では
+    # ないので、nil を返して呼び出し側に判断を委ねる。
+    def self.git_head
+      return `git rev-parse HEAD 2>/dev/null`.strip
+    rescue StandardError
+      return nil
+    end
+  end
+end

--- a/lib/relay/sentry_setup.rb
+++ b/lib/relay/sentry_setup.rb
@@ -1,4 +1,5 @@
 require 'sentry-ruby'
+require_relative 'revision'
 
 module Relay
   # Sentry 初期化と、計装コードから使う薄いヘルパ群。SENTRY_DSN が未設定なら
@@ -32,12 +33,10 @@ module Relay
       return Sentry.initialized?
     end
 
+    # `/health` の revision と同じ文字列を返す (#37)。取得ロジックの実体は
+    # [Relay::Revision] にあり、ここは Sentry 側の呼び名を残しているだけ。
     def self.detect_release
-      explicit = ENV.fetch('SENTRY_RELEASE', nil)
-      return explicit if explicit
-
-      sha = `git rev-parse HEAD 2>/dev/null`.strip
-      return sha.empty? ? nil : sha
+      return Relay::Revision.current
     end
 
     # device token / push token を部分マスクして Sentry に送る (#10 Phase E)。

--- a/test/announcement_worker_test.rb
+++ b/test/announcement_worker_test.rb
@@ -22,9 +22,10 @@ class AnnouncementWorkerTest < Minitest::Test
       @pushes = []
     end
 
+    # 返り値は deliver 側で使われない。真偽だけを返すと
+    # Naming/PredicateMethod に引っかかるので記録した配列をそのまま返す。
     def push(**kwargs)
-      @pushes << kwargs
-      return true
+      return @pushes << kwargs
     end
   end
 
@@ -109,7 +110,7 @@ class AnnouncementWorkerTest < Minitest::Test
     worker.send(
       :deliver,
       sub: {'device_type' => 'macos', 'token' => 'tok', 'account' => 'a@b'},
-      payload: {}, alert: {},
+      payload: {}, alert: {}
     )
   end
 end

--- a/test/revision_test.rb
+++ b/test/revision_test.rb
@@ -1,0 +1,65 @@
+require_relative 'test_helper'
+require 'lib/relay/revision'
+require 'lib/relay/sentry_setup'
+
+# #37 稼働中の commit SHA の解決。
+#
+# `/health` の `revision` と Sentry の `release` が**同じ文字列**であることが
+# この値の主用途なので、両者が同じ [Relay::Revision] を通ることまで固定する。
+# 片方だけ別ロジックに戻ると、突き合わせの前に変換が要る値に静かに戻る。
+class RevisionTest < Minitest::Test
+  def teardown
+    Relay::Revision.reset!
+  end
+
+  def test_env_is_used_when_present
+    sha = Relay::Revision.resolve(
+      env: {'SENTRY_RELEASE' => 'abc123'}, head: 'deadbeef',
+    )
+
+    assert_equal('abc123', sha)
+  end
+
+  def test_git_head_is_used_when_env_is_absent
+    assert_equal('deadbeef', Relay::Revision.resolve(env: {}, head: 'deadbeef'))
+  end
+
+  # env が空文字（未設定と同義の設定ミス）でも git へ落ちる。
+  def test_blank_env_falls_back_to_git
+    sha = Relay::Revision.resolve(env: {'SENTRY_RELEASE' => ''}, head: 'deadbeef')
+
+    assert_equal('deadbeef', sha)
+  end
+
+  # git チェックアウト外・git 未導入。名乗れないのは異常ではないので nil を
+  # 返し、`/health` は null を出す（落とさない）。
+  def test_returns_nil_when_nothing_is_available
+    assert_nil(Relay::Revision.resolve(env: {}, head: ''))
+  end
+
+  def test_surrounding_whitespace_is_stripped
+    assert_equal('deadbeef', Relay::Revision.resolve(env: {}, head: "deadbeef\n"))
+  end
+
+  # `/health` は監視から定期的に叩かれる。毎回 `git rev-parse` を fork しない。
+  def test_current_is_memoized
+    Relay::Revision.reset!
+    first = Relay::Revision.current
+
+    assert_same(first, Relay::Revision.current)
+  end
+
+  # 本番の実体（git チェックアウト）では実際に名乗れる。ここが落ちるなら
+  # デプロイ形態が変わった合図。
+  def test_current_resolves_in_this_checkout
+    omit('SENTRY_RELEASE が設定された環境') unless ENV.fetch('SENTRY_RELEASE', '').empty?
+    Relay::Revision.reset!
+
+    assert_match(/\A[0-9a-f]{40}\z/, Relay::Revision.current)
+  end
+
+  # Sentry の release と `/health` の revision を同じ値に保つ (#37 の主目的)。
+  def test_sentry_release_is_the_same_value
+    assert_equal(Relay::Revision.current, Relay::SentrySetup.detect_release)
+  end
+end


### PR DESCRIPTION
Closes #37

`/health` が稼働中のコードを名乗らず、本番の版を知るには flauros へ SSH して `git rev-parse HEAD` する必要があった。

## 名乗るのは SHA

relay は **main への merge がそのまま本番の単位**で、capsicum のリリースとは独立に進む（マイルストーン名だけ揃えている）。「1.57.0」と名乗らせても実際に動いているコードと 1 対 1 で対応しないので、切り分けで効く粒度＝commit SHA を出す。

```json
{
  "status": "ok",
  "revision": "0530a9a…",
  "subscriptions": 179,
  "announcement_subscriptions": 27,
  "supporters": 46
}
```

## Sentry の release と同じ文字列にする

⚠ **これが主目的。** 変換なしで突き合わせられないと、Sentry の release 別グラフと `/health` を並べるたびに変換が要る値に戻る。そこで `SentrySetup.detect_release` の取得ロジックを `Relay::Revision` へ切り出し、**Sentry 初期化と `/health` の両方が同じところを通る**形にした。`test_sentry_release_is_the_same_value` で一致を固定してある。

新しい仕組みは足していない（`SENTRY_RELEASE` env 優先 → `git rev-parse HEAD` フォールバックの順序も従来どおり）。

## 実装メモ

- **SHA は 1 度だけ解決して覚える。** `/health` は監視から定期的に叩かれるので、毎回 `git rev-parse` を fork するのは素直に無駄。デプロイは再起動を伴うのでプロセス内で値は変わらない
- **取得できないときは `null`。** git チェックアウト外・git 未導入でも落とさない（`detect_release` が元々 nil を返す形なのに揃えた）

## テスト

`test/revision_test.rb` 8 件。env 優先 / git フォールバック / 空 env / 取得不能 / 空白除去 / メモ化 / このチェックアウトで実際に 40 桁 hex が取れること / Sentry release との一致。

`rake test` **60 runs 0 failures**・`rubocop` **no offenses**。

⚠ **`/health` の route 自体の request テストはまだ無い**（`app.rb` が `config/settings.yml` 依存で require できないため）。土台は #34 で入れるので、そこで `/health` の request テストを足して revision の出力まで覆う。

## ついでに

#36 で入れたテストの rubocop offense 2 件（`Naming/PredicateMethod` / `Style/TrailingCommaInArguments`）を直した。前回 rubocop をかけそびれていた分。

## デプロイ後の確認

`/health` の `revision` が flauros の `git rev-parse HEAD` と一致することを見る（#37 のチェックリスト最終項目）。