### PR TITLE
fix: request テストが外部の DB を消しうる形を塞ぐ (Codex P1 / #34)

### DIFF
--- a/test/request_isolation_test.rb
+++ b/test/request_isolation_test.rb
@@ -1,0 +1,48 @@
+require_relative 'support/request_test_case'
+
+# 🔴 request テストが**自分の一時 DB 以外を絶対に消さない**ことの回帰テスト
+# （Codex P1・PR #40）。
+#
+# `setup` は毎回 `DELETE FROM` でテーブルを空にする。シェルに `RELAY_DB_PATH` が
+# 設定された環境で `rake test` を叩いたときにそこを消してしまう、というのが
+# 指摘の中身だった。
+class RequestIsolationTest < RequestTestCase
+  def test_uses_the_tmpdir_created_by_this_process
+    assert(
+      ENV.fetch('RELAY_DB_PATH').start_with?("#{RELAY_TEST_DB_DIR}/"),
+      'テストは自分で作った一時ディレクトリの DB を見ること',
+    )
+  end
+
+  # 設定も固定する（本番の秘密情報をテストに読ませない）。
+  def test_uses_the_fixture_settings
+    assert_equal(
+      File.expand_path('fixtures/settings.yml', __dir__),
+      ENV.fetch('RELAY_CONFIG_PATH'),
+    )
+    assert_equal('test-secret', Relay::BaseApp.settings.config['shared_secret'])
+  end
+
+  # 多重防御。env 固定が将来ほどけても、外の DB は truncate しない。
+  def test_refuses_to_truncate_a_database_outside_the_tmpdir
+    original = ENV.fetch('RELAY_DB_PATH')
+    ENV['RELAY_DB_PATH'] = '/tmp/definitely-not-ours.sqlite3'
+
+    error = assert_raises(RuntimeError) {safe_db_path}
+
+    assert_match('refusing to truncate', error.message)
+  ensure
+    ENV['RELAY_DB_PATH'] = original
+  end
+
+  # ⚠ prefix 一致だけだと `/tmp/xxx-evil` のような隣接パスを通してしまう。
+  # 区切りまで含めて見ていることを固定する。
+  def test_sibling_directory_with_the_same_prefix_is_rejected
+    original = ENV.fetch('RELAY_DB_PATH')
+    ENV['RELAY_DB_PATH'] = "#{RELAY_TEST_DB_DIR}-evil/relay.sqlite3"
+
+    assert_raises(RuntimeError) {safe_db_path}
+  ensure
+    ENV['RELAY_DB_PATH'] = original
+  end
+end

--- a/test/support/request_test_case.rb
+++ b/test/support/request_test_case.rb
@@ -8,15 +8,20 @@ require 'tmpdir'
 # クラス定義時に走るので、ここで指しておかないと本番の settings.yml / DB を
 # 掴もうとする（無ければそのまま落ちる）。これが #34 で「app.rb は
 # config/settings.yml 依存で require できない」と書かれていたブロッカーの実体。
-ENV['RELAY_CONFIG_PATH'] ||= File.expand_path('../fixtures/settings.yml', __dir__)
-unless ENV['RELAY_DB_PATH']
-  dir = Dir.mktmpdir('capsicum-relay-request-test')
-  # ⚠ **`at_exit` は使えない。** minitest/autorun が先に at_exit を登録して
-  # いるので、後から登録したハンドラの方が**先に**走る＝テストが 1 件も動く前に
-  # 一時ディレクトリが消える。`Minitest.after_run` はテスト完了後に走る。
-  Minitest.after_run {FileUtils.remove_entry(dir)}
-  ENV['RELAY_DB_PATH'] = File.join(dir, 'relay.sqlite3')
-end
+# 🔴 **既存の値を尊重しない（Codex P1・PR #40）。** `RequestTestCase#setup` は
+# 毎回 `DELETE FROM` でテーブルを空にするので、シェルに `RELAY_DB_PATH` が
+# 設定された環境（サービスを動かすために export してあるなど）で
+# `rake test` を叩くと**そのデータベースを消す**。テストプロセスは常に
+# 自分で作った一時ファイルだけを見る。設定ファイルも同じ理由で固定する
+# （本番の秘密情報をテストに読ませない）。
+ENV['RELAY_CONFIG_PATH'] = File.expand_path('../fixtures/settings.yml', __dir__)
+
+# ⚠ **`at_exit` は使えない。** minitest/autorun が先に at_exit を登録して
+# いるので、後から登録したハンドラの方が**先に**走る＝テストが 1 件も動く前に
+# 一時ディレクトリが消える。`Minitest.after_run` はテスト完了後に走る。
+RELAY_TEST_DB_DIR = Dir.mktmpdir('capsicum-relay-request-test')
+Minitest.after_run {FileUtils.remove_entry(RELAY_TEST_DB_DIR)}
+ENV['RELAY_DB_PATH'] = File.join(RELAY_TEST_DB_DIR, 'relay.sqlite3')
 
 require 'rack/test'
 require 'app'
@@ -51,11 +56,23 @@ class RequestTestCase < Minitest::Test
   end
 
   def setup
-    db = SQLite3::Database.new(ENV.fetch('RELAY_DB_PATH'))
+    db = SQLite3::Database.new(safe_db_path)
     # 子から先に消す（subscriptions を先に消すと FK ON DELETE CASCADE 頼みに
     # なり、意図せず「消えたこと」を検証してしまう）。
     TABLES.each {|table| db.execute("DELETE FROM #{table}")}
     db.close
+  end
+
+  # 🔴 消してよい DB かを毎回確かめる（Codex P1・PR #40 の多重防御）。
+  # 上の env 固定が将来ほどけても、**このプロセスが作った一時ディレクトリの
+  # 外を DELETE しない**。
+  def safe_db_path
+    path = ENV.fetch('RELAY_DB_PATH')
+    unless path.start_with?("#{RELAY_TEST_DB_DIR}/")
+      raise "refusing to truncate a database outside the test tmpdir: #{path}"
+    end
+
+    return path
   end
 
   # 認証つきの JSON POST / DELETE / GET。ヘッダ名を各ケースで書かない。


### PR DESCRIPTION
PR #40 に付いた Codex の **P1** への対応。指摘は正しい。

## 何が起きうるか

`RequestTestCase#setup` は毎回 `DELETE FROM` で `subscriptions` / `announcement_subscriptions` / `supporters` を空にする。ところが harness が **既存の `RELAY_DB_PATH` を尊重していた**（`unless ENV['RELAY_DB_PATH']`）ので、サービスを動かすためにその env を export しているシェルで `rake test` を叩くと、**そのデータベースの中身が消える**。

## 直し方

1. **env は既存値を尊重せず常に上書きする。** DB はこのプロセスが `Dir.mktmpdir` で作ったもの、設定は fixture に固定（ついでに本番の秘密情報もテストに読ませない）
2. **多重防御。** truncate の直前にパスが一時ディレクトリ配下かを確認し、外なら例外で止める。1 が将来ほどけても消さない

⚠ prefix 一致だけだと `<tmpdir>-evil/…` のような隣接パスを通してしまうので、区切りまで含めて判定している。

## 確認

汚染環境で再現しないことを実測した。

```console
$ RELAY_DB_PATH=/tmp/should-not-be-touched.sqlite3 \
  RELAY_CONFIG_PATH=/nonexistent.yml bundle exec rake test
120 runs, 271 assertions, 0 failures, 0 errors, 0 skips

$ ls /tmp/should-not-be-touched.sqlite3
ls: /tmp/should-not-be-touched.sqlite3: No such file or directory
```

指定した DB は**作られてすらいない**。回帰テストは `test/request_isolation_test.rb` に 4 件。

`rake test` 120 runs / 0 failures・`rubocop` no offenses。

## 影響範囲

テスト専用の経路で、本番コードは触っていない。flauros は `BUNDLE_WITHOUT=development` で minitest / rake が入らないため、本番でこれが踏まれたことはない。