### PR TITLE
feat: 構造化ログ / request_id / メトリクスを入れる (#2)

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -1,6 +1,7 @@
 require_relative 'lib/relay/base_app'
 require_relative 'lib/relay/routes/announcement_subscriptions'
 require_relative 'lib/relay/routes/health'
+require_relative 'lib/relay/routes/metrics'
 require_relative 'lib/relay/routes/push'
 require_relative 'lib/relay/routes/register'
 require_relative 'lib/relay/routes/supporters'
@@ -23,6 +24,7 @@ module Relay
 
     use Routes::AnnouncementSubscriptions
     use Routes::Health
+    use Routes::Metrics
     use Routes::Push
     use Routes::Register
     use Routes::Supporters

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -184,19 +184,40 @@ curl https://relay.capsicum.shrieker.net/health
 
 #### なぜ Sentry だけでは足りないか
 
-- relay が Sentry へ上げているのは**失敗側だけ**。成功は `logger.info` にしか出ない（`Pushed to <device_type>: <account>`）ので、Sentry を見ると失敗だけが並び、母数が見えない
+- relay が Sentry へ上げているのは**失敗側だけ**。成功は journald と `/metrics` にしか出ないので、Sentry を見ると失敗だけが並び、母数が見えない
 - WNS の `dropped` は**端末がオフライン / スリープで受け取れなかった**という正常系。PC を消している時間が長い利用者ほど積み上がるので、件数の多さは不具合の証拠にならない
 - capsicum 側の `push.wns_bgtask: bgtask.shown` は、bg task が LocalState に書いた記録を**次回アプリ起動時に**回収して送る方式。**「出ていない ＝ トーストが出ていない」ではない**（アプリを起動していないだけ）
 
 #### 手順
 
+まず `/metrics` で母数と内訳を見る（#2）。14 日ぶんの journald を走査する前に、「そもそも relay に届いているか / 送れているか」がここで分かる。
+
+```bash
+curl -s -H "X-Relay-Secret: $SECRET" https://relay.capsicum.shrieker.net/metrics \
+  | grep relay_push_total
+```
+
+`relay_push_total{device_type,outcome}` の `outcome` は `success` / `deduped` / `degraded` / `gone` / `oversized` / `failed` / `wns_<status>`。⚠ **counter はプロセス再起動でゼロに戻る**（in-memory）。再起動の位置は `/health` の `revision` の変化で分かる。
+
+期間や個別アカウントを見るときは journald を読む。ログは **1 行 = 1 JSON**（#2）。
+
 ```bash
 ssh deploy@flauros.b-shock.co.jp
+journalctl -u capsicum-relay --no-pager --since "-14 days" -o cat \
+  | grep '"event":"push.result"' \
+  | jq -r '[.ts, .device_type, .outcome, .account] | @tsv'
+```
+
+⚠ **従来の grep もそのまま効く。** JSON の中に人間向けの `msg`（`Pushed to windows: <account>` / `WNS delivered but dropped: <account>`）を同じ文言で残してあるため。
+
+```bash
 journalctl -u capsicum-relay --no-pager --since "-14 days" -o short-iso \
   | grep -E "Pushed to windows:|WNS delivered but dropped:"
 ```
 
-`Pushed to <device_type>:` が成功、`WNS delivered but dropped:` が drop。アカウント別に数えて成功率を出し、さらに**時刻（JST）別の分布**を見る。
+`outcome=success`（＝`Pushed to <device_type>:`）が成功、`outcome=wns_dropped`（＝`WNS delivered but dropped:`）が drop。アカウント別に数えて成功率を出し、さらに**時刻（JST）別の分布**を見る。
+
+`request_id` は応答の `X-Request-Id` と同じ値で、Sentry イベントにも同名の tag が乗る。特定の 1 リクエストを追うときはこれで 3 者を突き合わせる。
 
 #### 判定基準
 

--- a/lib/relay/base_app.rb
+++ b/lib/relay/base_app.rb
@@ -1,13 +1,17 @@
 require 'json'
 require 'logger'
+require 'securerandom'
 require 'sinatra/base'
 require 'yaml'
 require_relative 'announcement_worker'
 require_relative 'apns_client'
 require_relative 'database'
 require_relative 'fcm_client'
+require_relative 'metrics'
 require_relative 'push_dedup'
 require_relative 'push_helpers'
+require_relative 'sentry_setup'
+require_relative 'structured_log'
 require_relative 'wns_client'
 
 module Relay
@@ -40,7 +44,9 @@ module Relay
     configure do
       set :config, YAML.load_file(config_path)
       set :database, Relay::Database.new(path: database_path)
-      set :logger, Logger.new($stdout)
+      # 1 行 = 1 JSON。人間向けの msg も同じ行に残す (#2・StructuredLog 参照)。
+      set :logger, Logger.new($stdout, formatter: Relay::StructuredLog::FORMATTER)
+      set :metrics, Relay::Metrics.new
 
       if settings.config.dig('apns', 'key_path')
         set :apns, Relay::ApnsClient.new(settings.config, logger: settings.logger)
@@ -75,6 +81,14 @@ module Relay
 
     before do
       content_type :json
+      start_request!
+    end
+
+    # 応答に request_id を返す。capsicum 側の Sentry breadcrumb と journald を
+    # 突き合わせるための取っ手 (#2)。⚠ **middleware として連なった route クラスの
+    # after も走る**ので、既に付いていれば上書きしない。
+    after do
+      headers['X-Request-Id'] = request_id
     end
 
     # push 送信・結果ハンドリング系（build_push_payload / dispatch_push /
@@ -100,6 +114,53 @@ module Relay
         return if missing.empty?
 
         halt 400, {error: "Missing fields: #{missing.join(', ')}"}.to_json
+      end
+
+      # request_id と開始時刻を env に置く (#2)。
+      #
+      # ⚠ **route クラスを middleware として連ねているので before が何度も走る**
+      # （一致しない route クラスも before を回してから forward する）。既に
+      # 置いてあれば触らない。
+      #
+      # 現状ログを書くのは一致した route だけなので、これが無くても出力される
+      # id は揃う。それでも先に置くのは 2 点のため:
+      # - `latency_ms` が**チェーン全体**を測る（毎回上書きすると、最後の
+      #   middleware から route までの区間しか測らなくなる）
+      # - Sentry の scope へ同じ tag を連鎖のぶん何度も投げない
+      def start_request!
+        return if request.env['relay.request_id']
+
+        # 上流 (nginx) が採番していればそれに乗る。無ければここで採る。
+        id = request.env['HTTP_X_REQUEST_ID'].to_s
+        id = SecureRandom.uuid if id.empty?
+        request.env['relay.request_id'] = id
+        request.env['relay.started_at'] = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        Relay::SentrySetup.tag_request(id)
+      end
+
+      def request_id
+        return request.env['relay.request_id']
+      end
+
+      def latency_ms
+        started_at = request.env['relay.started_at']
+        return nil unless started_at
+
+        elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at
+        return (elapsed * 1000).round
+      end
+
+      # 構造化ログの入口 (#2)。`msg` は人間向けの 1 行で、grep 手順を壊さないため
+      # 従来と同じ文言を渡す。それ以外は jq で集計するためのフィールド。
+      def log_event(event, msg:, level: :info, **fields)
+        settings.logger.public_send(
+          level,
+          {event: event, request_id: request_id, msg: msg}.merge(fields),
+        )
+      end
+
+      def metrics
+        return settings.metrics
       end
     end
   end

--- a/lib/relay/base_app.rb
+++ b/lib/relay/base_app.rb
@@ -43,9 +43,13 @@ module Relay
 
     configure do
       set :config, YAML.load_file(config_path)
-      set :database, Relay::Database.new(path: database_path)
+      # ⚠ **logger を先に作る。** Database / 各クライアントは construct 時の
+      # logger を握るので、あとから set しても差し替わらない。順番を崩すと
+      # 孤児 subscription の掃除 (Database#purge_legacy_rows 等) だけが素の
+      # Logger で出て、「1 行 = 1 JSON」の約束が破れる (Codex P2 / PR #42)。
       # 1 行 = 1 JSON。人間向けの msg も同じ行に残す (#2・StructuredLog 参照)。
       set :logger, Logger.new($stdout, formatter: Relay::StructuredLog::FORMATTER)
+      set :database, Relay::Database.new(path: database_path, logger: settings.logger)
       set :metrics, Relay::Metrics.new
 
       if settings.config.dig('apns', 'key_path')

--- a/lib/relay/metrics.rb
+++ b/lib/relay/metrics.rb
@@ -1,0 +1,99 @@
+require 'monitor'
+
+module Relay
+  # プロセス内カウンタと Prometheus 形式の露出 (#2)。
+  #
+  # 構造化ログ (#2 の本体) があれば journald + jq で後追い集計はできるが、
+  # **「今どうなっているか」を一発で見る母数**が要る場面がある — 配信不達の
+  # 切り分けで最初に見るのは「そもそも relay に届いているか / 送れているか」で、
+  # そこを 14 日ぶんの journald 走査から始めるのは重い。
+  #
+  # 格納はプロセス内 Hash を Monitor で保護する。config/puma.rb は `workers 0`
+  # （単一プロセス＋スレッド）なので全リクエストで共有できる。⚠ PushDedup と
+  # **同じ前提に乗っている**ので、workers > 0 にするなら両方まとめて共有ストアへ
+  # 移す必要がある。
+  #
+  # ⚠ **プロセス再起動でゼロに戻る。** Prometheus の counter は単調増加を前提に
+  # `rate()` を取るので、再起動をまたぐ差分は scraper 側が扱う（`revision` が
+  # 変わるので再起動の位置は #37 の値で分かる）。
+  class Metrics
+    # 出す counter の定義。`# HELP` / `# TYPE` を書くために名前と説明を持つ。
+    COUNTERS = {
+      'relay_push_total' => 'Web Push received from upstream, by device_type and outcome.',
+      'relay_register_total' => 'Device registration changes, by action.',
+      'relay_announcement_subscription_total' =>
+        'Announcement subscription changes, by action.',
+      'relay_supporter_tip_total' => 'Supporter tips recorded.',
+    }.freeze
+
+    def initialize
+      @counters = Hash.new(0)
+      @mon = Monitor.new
+    end
+
+    # [labels] はラベル名 => 値。値は Prometheus のラベル値として出す。
+    def increment(name, labels = {}, by: 1)
+      @mon.synchronize {@counters[[name, normalize(labels)]] += by}
+    end
+
+    def value(name, labels = {})
+      return @mon.synchronize {@counters[[name, normalize(labels)]]}
+    end
+
+    def reset!
+      @mon.synchronize {@counters.clear}
+    end
+
+    # Prometheus text exposition format。[gauges] は名前 => [説明, 値] で、
+    # DB から都度読む現在値（購読数など）を渡す。
+    def to_prometheus(gauges: {})
+      lines = []
+      COUNTERS.each do |name, help|
+        lines.concat(counter_lines(name, help))
+      end
+      gauges.each do |name, (help, value)|
+        lines << "# HELP #{name} #{help}"
+        lines << "# TYPE #{name} gauge"
+        lines << "#{name} #{value}"
+      end
+      return "#{lines.join("\n")}\n"
+    end
+
+    private
+
+    # ⚠ **値が 0 でも系列を出す。** 一度も起きていない outcome の系列が消えると、
+    # Prometheus 側で「まだ起きていない」と「scrape できていない」が区別できない。
+    # ただし出せるのは実際に観測したラベルの組み合わせだけなので、起動直後は
+    # 系列そのものが無い（counter の名前と HELP は必ず出す）。
+    def counter_lines(name, help)
+      lines = ["# HELP #{name} #{help}", "# TYPE #{name} counter"]
+      snapshot(name).each do |labels, value|
+        lines << "#{name}#{render_labels(labels)} #{value}"
+      end
+      return lines
+    end
+
+    def snapshot(name)
+      return @mon.synchronize do
+        @counters.select {|(counter, _), _| counter == name}
+            .to_h {|(_, labels), value| [labels, value]}
+      end
+    end
+
+    def normalize(labels)
+      return labels.to_h {|key, value| [key.to_s, value.to_s]}.sort.to_h
+    end
+
+    def render_labels(labels)
+      return '' if labels.empty?
+
+      body = labels.map {|key, value| %(#{key}="#{escape(value)}")}.join(',')
+      return "{#{body}}"
+    end
+
+    # Prometheus のラベル値でエスケープが要るのは `\` / `"` / 改行の 3 つ。
+    def escape(value)
+      return value.gsub('\\', '\\\\\\\\').gsub('"', '\"').gsub("\n", '\n')
+    end
+  end
+end

--- a/lib/relay/push_helpers.rb
+++ b/lib/relay/push_helpers.rb
@@ -18,6 +18,29 @@ module Relay
     # （手順は docs/CLAUDE.md「配信不達の切り分け」）。
     WNS_BENIGN_STATUSES = ['dropped'].freeze
 
+    # push 1 通の結末を、構造化ログ 1 行と counter 1 つに落とす (#2)。
+    #
+    # ⚠ **outcome はここを唯一の出口にする。** 従来は結末ごとに logger 呼び出しが
+    # 散っていて、新しい結末を足すたびに計装を書き忘れる形だった（WNS の
+    # `dropped` が長らく件数として見えなかったのがそれ）。
+    #
+    # `msg` は従来と同じ文言。docs/CLAUDE.md「配信不達の切り分け」の grep 手順を
+    # 壊さないため（Relay::StructuredLog 参照）。
+    def record_push_outcome(sub, outcome, msg:, level: :info, **fields)
+      metrics.increment(
+        'relay_push_total', {device_type: sub['device_type'], outcome: outcome}
+      )
+      log_event(
+        'push.result', msg: msg, level: level,
+        outcome: outcome,
+        device_type: sub['device_type'],
+        account: sub['account'],
+        server: sub['server'],
+        latency_ms: latency_ms,
+        **fields
+      )
+    end
+
     def build_push_payload(sub)
       payload = {
         'body' => Base64.strict_encode64(request.body.read),
@@ -59,21 +82,44 @@ module Relay
     end
 
     def log_push_received(sub)
-      # 各サーバーがどの暗号化形式で送ってくるかを diagnose できるよう、
-      # Content-Encoding と関連ヘッダの有無をログに残す (#5)。機密情報は
-      # 含まないため常時出力。capsicum 側の復号 (#336) 検証時に役立つ。
-      encoding = request.env['HTTP_CONTENT_ENCODING'].to_s
-      crypto_key = request.env['HTTP_CRYPTO_KEY'] ? '+ck' : ''
-      encryption = request.env['HTTP_ENCRYPTION'] ? '+enc' : ''
-      # len / topic は dedup (#16) の判別材料の効きを後追いするための観測。
-      # 同一通知の重複バーストが同一 len かつ、別通知が別 len になっているかを
-      # ログで検証してから窓・キーを調整する。
-      topic = request.env['HTTP_TOPIC'] ? '+topic' : ''
-      settings.logger.info(
-        "Received push: #{sub['account']} (#{sub['device_type']}," \
-          " encoding=#{encoding.inspect}#{crypto_key}#{encryption}" \
-          " len=#{request.content_length}#{topic})",
+      log_event(
+        'push.received',
+        msg: push_received_message(sub),
+        device_type: sub['device_type'],
+        account: sub['account'],
+        server: sub['server'],
+        # ⚠ push_token は capability secret。指紋だけ残す。
+        push_token: Relay::StructuredLog.fingerprint(sub['push_token']),
+        **push_received_fields,
       )
+    end
+
+    # 各サーバーがどの暗号化形式で送ってくるかを diagnose できるようにする (#5)。
+    # len / topic は dedup (#16) の判別材料の効きを後追いするための観測で、同一
+    # 通知の重複バーストが同一 len かつ別通知が別 len になっているかを見てから
+    # 窓・キーを調整する。機密情報は含まないため常時出力。
+    def push_received_fields
+      return {
+        encoding: request.env['HTTP_CONTENT_ENCODING'].to_s,
+        has_crypto_key: !request.env['HTTP_CRYPTO_KEY'].nil?,
+        has_encryption: !request.env['HTTP_ENCRYPTION'].nil?,
+        has_topic: !request.env['HTTP_TOPIC'].nil?,
+        # Rack は String で返す。jq で数値比較したいので整数に寄せる。
+        length: request.content_length&.to_i,
+      }
+    end
+
+    # 従来と同じ 1 行。docs/CLAUDE.md「配信不達の切り分け」の grep 手順を壊さない。
+    def push_received_message(sub)
+      fields = push_received_fields
+      flags = [
+        (fields[:has_crypto_key] ? '+ck' : ''),
+        (fields[:has_encryption] ? '+enc' : ''),
+      ].join
+      topic = fields[:has_topic] ? '+topic' : ''
+      return "Received push: #{sub['account']} (#{sub['device_type']}," \
+        " encoding=#{fields[:encoding].inspect}#{flags}" \
+        " len=#{fields[:length]}#{topic})"
     end
 
     def handle_push_result(sub, result)
@@ -104,7 +150,7 @@ module Relay
       return handle_wns_status(sub, result, wns_status) if wns_status && wns_status != 'received'
       return handle_push_degraded(sub, result) if result[:degraded]
 
-      settings.logger.info("Pushed to #{sub['device_type']}: #{sub['account']}")
+      record_push_outcome(sub, 'success', msg: "Pushed to #{sub['device_type']}: #{sub['account']}")
       return {status: 'delivered'}.to_json
     end
 
@@ -115,9 +161,11 @@ module Relay
     # 別メッセージにして、本当の不達が 0 になったことを確認できるようにする。件数が
     # 青天井になるようなら WNS_BENIGN_STATUSES と同じくログのみへ落とす。
     def handle_push_degraded(sub, result)
-      settings.logger.warn(
-        "Push degraded to generic alert: #{sub['account']}" \
+      record_push_outcome(
+        sub, 'degraded', level: :warn,
+        msg: "Push degraded to generic alert: #{sub['account']}" \
           " (#{sub['device_type']}, #{result[:original_size]}B)",
+        original_size: result[:original_size]
       )
       Relay::SentrySetup.capture_message(
         "Push oversized degraded (#{sub['device_type']})",
@@ -134,10 +182,11 @@ module Relay
     def handle_wns_status(sub, result, wns_status)
       benign = WNS_BENIGN_STATUSES.include?(wns_status)
       message = "WNS delivered but #{wns_status}: #{sub['account']}"
-      if benign
-        settings.logger.info(message)
-      else
-        settings.logger.warn(message)
+      record_push_outcome(
+        sub, "wns_#{wns_status}", level: benign ? :info : :warn,
+        msg: message, wns_status: wns_status
+      )
+      unless benign
         Relay::SentrySetup.capture_message(
           "WNS notification #{wns_status} (windows)",
           level: :warning,
@@ -153,7 +202,10 @@ module Relay
       # relay 側の行も掃除する。
       settings.database.unregister(sub['id'])
       reason = result[:reason] || result[:status]
-      settings.logger.info("Subscription gone: #{sub['account']} (#{reason})")
+      record_push_outcome(
+        sub, 'gone',
+        msg: "Subscription gone: #{sub['account']} (#{reason})", reason: reason
+      )
       status 410
       return {status: 'gone', detail: result}.to_json
     end
@@ -163,9 +215,11 @@ module Relay
       # subscription は健全なので unregister せず、Mastodon にも 413 を
       # 返してこの 1 通だけドロップさせる。permanent: false のままだと
       # Mastodon が retry を続けてログを汚すため、ここで明示的に止める (#9)。
-      settings.logger.warn(
-        "Push oversized (subscription kept): #{sub['account']}" \
+      record_push_outcome(
+        sub, 'oversized', level: :warn,
+        msg: "Push oversized (subscription kept): #{sub['account']}" \
           " (#{sub['device_type']}): #{result}",
+        reason: result[:reason] || result[:status]
       )
       # 健全な subscription を残したまま 1 通だけドロップする想定挙動だが、
       # 多発は送信側のペイロード設計問題を示すので warning として件数観測する
@@ -180,7 +234,10 @@ module Relay
     end
 
     def handle_push_failed(sub, result)
-      settings.logger.error("Push failed: #{result}")
+      record_push_outcome(
+        sub, 'failed', level: :error,
+        msg: "Push failed: #{result}", reason: result[:reason] || result[:status]
+      )
       # 一過性でない送信失敗（APNs / FCM の 5xx 等）。低頻度・高インパクトなので
       # journalctl 任せにせず Sentry で alert 駆動にする (#10 Phase B、#8 の後継観測)。
       Relay::SentrySetup.capture_message(

--- a/lib/relay/routes/announcement_subscriptions.rb
+++ b/lib/relay/routes/announcement_subscriptions.rb
@@ -22,7 +22,12 @@ module Relay
 
         # account は既に user@host 形式なので server は付けない（@host が二重に
         # 出るのを避ける）。push 登録ログ (handle_push_*) と表記を揃える。
-        settings.logger.info("Registered announcement: #{sub['account']} (#{sub['server']})")
+        metrics.increment('relay_announcement_subscription_total', {action: 'created'})
+        log_event(
+          'announcement_subscription.created',
+          msg: "Registered announcement: #{sub['account']} (#{sub['server']})",
+          account: sub['account'], server: sub['server'], latency_ms: latency_ms
+        )
         status 201
         sub.to_json
       end
@@ -33,8 +38,11 @@ module Relay
         sub = settings.database.unregister_announcement_subscription(params[:id].to_i)
         halt 404, {error: 'Not found'}.to_json unless sub
 
-        settings.logger.info(
-          "Unregistered announcement: #{sub['account']}@#{sub['server']}",
+        metrics.increment('relay_announcement_subscription_total', {action: 'deleted'})
+        log_event(
+          'announcement_subscription.deleted',
+          msg: "Unregistered announcement: #{sub['account']}@#{sub['server']}",
+          account: sub['account'], server: sub['server'], latency_ms: latency_ms
         )
         sub.to_json
       end

--- a/lib/relay/routes/metrics.rb
+++ b/lib/relay/routes/metrics.rb
@@ -1,0 +1,42 @@
+require_relative '../base_app'
+
+module Relay
+  module Routes
+    # Prometheus 形式のメトリクス (#2)。
+    #
+    # ⚠ **認証必須にしている。** 購読数・投げ銭件数は運用上の実数で、公開する
+    # 理由が無い。`/health` を無認証にしてあるのは監視から叩くためで、そちらは
+    # 「生きているか」しか出さない。
+    #
+    # ⚠ **counter はプロセス再起動でゼロに戻る**（in-memory）。Prometheus 側は
+    # counter reset を扱えるので `rate()` は壊れない。再起動の位置は `/health` の
+    # `revision` (#37) と突き合わせられる。
+    class Metrics < BaseApp
+      get '/metrics' do
+        authenticate!
+
+        content_type 'text/plain; version=0.0.4; charset=utf-8'
+        settings.metrics.to_prometheus(gauges: gauges)
+      end
+
+      helpers do
+        # DB から都度読む現在値。counter と違って再起動をまたいで意味を保つ。
+        def gauges
+          return {
+            'relay_subscriptions' => [
+              'Registered device subscriptions.', settings.database.count
+            ],
+            'relay_announcement_subscriptions' => [
+              'Announcement push subscriptions.',
+              settings.database.announcement_subscription_count,
+            ],
+            'relay_supporters' => [
+              'Supporters who have tipped at least once.',
+              settings.database.supporter_count,
+            ],
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/relay/routes/push.rb
+++ b/lib/relay/routes/push.rb
@@ -49,7 +49,10 @@ module Relay
             length: request.content_length,
           )
 
-          settings.logger.info("Push deduped (#{sub['device_type']}): #{sub['account']}")
+          record_push_outcome(
+            sub, 'deduped',
+            msg: "Push deduped (#{sub['device_type']}): #{sub['account']}"
+          )
           return true
         end
       end

--- a/lib/relay/routes/register.rb
+++ b/lib/relay/routes/register.rb
@@ -22,9 +22,16 @@ module Relay
           device_id: json_body['device_id'],
         )
 
-        settings.logger.info(
-          "Registered: #{sub['account']} (#{sub['device_type']}," \
+        metrics.increment('relay_register_total', {action: 'created'})
+        log_event(
+          'register.created',
+          msg: "Registered: #{sub['account']} (#{sub['device_type']}," \
             " device_id=#{sub['device_id'] ? 'yes' : 'none'})",
+          device_type: sub['device_type'],
+          account: sub['account'],
+          server: sub['server'],
+          has_device_id: !sub['device_id'].nil?,
+          latency_ms: latency_ms,
         )
         status 201
         sub.to_json
@@ -36,7 +43,12 @@ module Relay
         sub = settings.database.unregister(params[:id].to_i)
         halt 404, {error: 'Not found'}.to_json unless sub
 
-        settings.logger.info("Unregistered: #{sub['account']}")
+        metrics.increment('relay_register_total', {action: 'deleted'})
+        log_event(
+          'register.deleted', msg: "Unregistered: #{sub['account']}",
+          device_type: sub['device_type'], account: sub['account'],
+          server: sub['server'], latency_ms: latency_ms
+        )
         sub.to_json
       end
 

--- a/lib/relay/routes/supporters.rb
+++ b/lib/relay/routes/supporters.rb
@@ -23,8 +23,12 @@ module Relay
           count: count,
         )
 
-        settings.logger.info(
-          "Supporter tip recorded: #{supporter['account']} (count=#{count})",
+        metrics.increment('relay_supporter_tip_total', {}, by: count)
+        log_event(
+          'supporter.tip',
+          msg: "Supporter tip recorded: #{supporter['account']} (count=#{count})",
+          account: supporter['account'], server: supporter['server'],
+          count: count, latency_ms: latency_ms
         )
         status 201
         supporter.to_json

--- a/lib/relay/sentry_setup.rb
+++ b/lib/relay/sentry_setup.rb
@@ -49,6 +49,14 @@ module Relay
       return "#{str[0, 6]}…#{str[-4, 4]}"
     end
 
+    # relay の journald と Sentry イベントを突き合わせるための request_id (#2)。
+    # 以降このリクエストで送るイベントに tag として乗る。
+    def self.tag_request(request_id)
+      return unless Sentry.initialized?
+
+      Sentry.configure_scope {|scope| scope.set_tag('request_id', request_id)}
+    end
+
     # 以下の capture 系 / breadcrumb は Sentry 未初期化時 (development / test) は
     # no-op。呼び出し側のガードをここに集約し、計装コードを簡潔に保つ。
 

--- a/lib/relay/structured_log.rb
+++ b/lib/relay/structured_log.rb
@@ -1,0 +1,46 @@
+require 'json'
+require 'time'
+
+module Relay
+  # 構造化ログ (#2)。1 行 = 1 JSON オブジェクトで journald に出す。
+  #
+  # ⚠ **人間向けの 1 行メッセージ (`msg`) を捨てない。** 配信不達の切り分け手順
+  # (docs/CLAUDE.md「配信不達の切り分け」) は journald を
+  # `grep "Pushed to windows:"` する形で回っており、JSON へ移った瞬間にその手順が
+  # 死ぬ。`msg` を同じ文言のまま JSON の中に持たせれば、**grep は今までどおり効き、
+  # 加えて jq で集計できる**。移行のコストを運用側に押し付けないための設計。
+  #
+  # ```console
+  # $ journalctl -u capsicum-relay | grep '"event":"push.delivered"' \
+  #     | jq -r '[.device_type, .outcome, .latency_ms] | @tsv'
+  # ```
+  module StructuredLog
+    # ::Logger に差す formatter。`logger.info(Hash)` なら中身を展開し、
+    # 文字列ならそのまま `msg` に入れる（未計装の呼び出しも JSON になる）。
+    FORMATTER = lambda do |severity, time, _progname, message|
+      record = {ts: time.utc.iso8601(3), level: severity}
+      if message.is_a?(Hash)
+        record.merge!(message)
+      else
+        record[:msg] = message.to_s
+      end
+      return "#{JSON.generate(compact(record))}\n"
+    end
+
+    # nil の項目は落とす。event ごとに出ない項目があるので、そのぶん行が短くなる。
+    def self.compact(record)
+      return record.compact
+    end
+
+    # push_token / device token は**それ自体が capability secret**。ログに全部を
+    # 残さない。相関を追うには十分な、先頭 6 文字＋長さの指紋にする。
+    # SentrySetup.mask_token と揃えると Sentry 側の値と目視で突き合わせられる。
+    def self.fingerprint(token)
+      str = token.to_s
+      return nil if str.empty?
+      return '*' * str.length if str.length <= 12
+
+      return "#{str[0, 6]}…#{str[-4, 4]}"
+    end
+  end
+end

--- a/test/metrics_test.rb
+++ b/test/metrics_test.rb
@@ -1,0 +1,85 @@
+require_relative 'test_helper'
+require 'lib/relay/metrics'
+
+# プロセス内カウンタと Prometheus 露出 (#2)。
+class MetricsTest < Minitest::Test
+  def setup
+    @metrics = Relay::Metrics.new
+  end
+
+  def test_counts_by_labels
+    @metrics.increment('relay_push_total', {device_type: 'ios', outcome: 'success'})
+    @metrics.increment('relay_push_total', {device_type: 'ios', outcome: 'success'})
+    @metrics.increment('relay_push_total', {device_type: 'windows', outcome: 'success'})
+
+    assert_equal(2, @metrics.value('relay_push_total', {device_type: 'ios', outcome: 'success'}))
+    assert_equal(
+      1, @metrics.value('relay_push_total', {device_type: 'windows', outcome: 'success'})
+    )
+  end
+
+  def test_counts_by_arbitrary_amount
+    @metrics.increment('relay_supporter_tip_total', {}, by: 3)
+
+    assert_equal(3, @metrics.value('relay_supporter_tip_total'))
+  end
+
+  # ラベルの順序と型（Symbol / String）で別系列にしない。
+  def test_label_order_and_type_do_not_split_series
+    @metrics.increment('relay_push_total', {device_type: 'ios', outcome: 'success'})
+    @metrics.increment('relay_push_total', {'outcome' => 'success', 'device_type' => 'ios'})
+
+    assert_equal(2, @metrics.value('relay_push_total', {outcome: 'success', device_type: 'ios'}))
+  end
+
+  def test_unobserved_series_is_zero
+    assert_equal(0, @metrics.value('relay_push_total', {device_type: 'ios', outcome: 'failed'}))
+  end
+
+  # counter の名前と HELP / TYPE は、まだ 1 件も観測していなくても出す。
+  def test_exposes_help_and_type_even_without_samples
+    text = @metrics.to_prometheus
+
+    assert_includes(text, '# TYPE relay_push_total counter')
+    assert_includes(text, '# HELP relay_push_total')
+  end
+
+  def test_renders_samples_with_labels
+    @metrics.increment('relay_push_total', {device_type: 'ios', outcome: 'success'})
+
+    assert_includes(
+      @metrics.to_prometheus, 'relay_push_total{device_type="ios",outcome="success"} 1'
+    )
+  end
+
+  def test_renders_labelless_samples
+    @metrics.increment('relay_supporter_tip_total')
+
+    assert_includes(@metrics.to_prometheus, "relay_supporter_tip_total 1\n")
+  end
+
+  def test_renders_gauges
+    text = @metrics.to_prometheus(gauges: {'relay_subscriptions' => ['Registered.', 179]})
+
+    assert_includes(text, '# TYPE relay_subscriptions gauge')
+    assert_includes(text, "relay_subscriptions 179\n")
+  end
+
+  # ラベル値のエスケープ。壊れた exposition を出すと scrape 全体が落ちる。
+  def test_escapes_quotes_in_label_values
+    @metrics.increment('relay_push_total', {device_type: 'a"b', outcome: 'success'})
+
+    assert_includes(@metrics.to_prometheus, 'device_type="a\"b"')
+  end
+
+  def test_ends_with_a_newline
+    assert(@metrics.to_prometheus.end_with?("\n"))
+  end
+
+  def test_reset_clears_counters
+    @metrics.increment('relay_push_total', {device_type: 'ios', outcome: 'success'})
+    @metrics.reset!
+
+    assert_equal(0, @metrics.value('relay_push_total', {device_type: 'ios', outcome: 'success'}))
+  end
+end

--- a/test/observability_route_test.rb
+++ b/test/observability_route_test.rb
@@ -160,6 +160,29 @@ class ObservabilityRouteTest < RequestTestCase
     assert_equal(1, records('push.received').size)
   end
 
+  # ⚠ Database / 各クライアントは construct 時の logger を握る。あとから set
+  # しても差し替わらないので、logger を先に作る順序が守られていないと孤児掃除の
+  # ログだけ素の Logger で出て「1 行 = 1 JSON」が破れる (Codex P2 / PR #42)。
+  # ⚠ setup がこのテスト用に settings.logger を差し替えているので、Database が
+  # 握っているのは configure 時の実体。同一性ではなく **formatter が構造化ログの
+  # ものであること** を見る（それが「1 行 = 1 JSON」の実体）。
+  def test_database_logs_through_the_structured_logger
+    assert_same(
+      Relay::StructuredLog::FORMATTER,
+      settings.database.instance_variable_get(:@logger).formatter,
+    )
+  end
+
+  # 出力された行がすべて JSON であること（未計装の呼び出しも formatter が包む）。
+  def test_every_line_is_json
+    register_subscription
+    settings.logger.info('uninstrumented line')
+
+    @log.string.each_line do |line|
+      JSON.parse(line)
+    end
+  end
+
   ## /metrics
 
   def test_metrics_requires_secret

--- a/test/observability_route_test.rb
+++ b/test/observability_route_test.rb
@@ -1,0 +1,195 @@
+require_relative 'support/request_test_case'
+
+# request をまたいだ観測の配線 (#2)。request_id / 構造化ログ / counter / /metrics。
+class ObservabilityRouteTest < RequestTestCase
+  def setup
+    super
+    settings.metrics.reset!
+    @log = StringIO.new
+    Relay::BaseApp.set(:logger, Logger.new(@log, formatter: Relay::StructuredLog::FORMATTER))
+  end
+
+  def teardown
+    Relay::BaseApp.set(:logger, Logger.new(File::NULL))
+  end
+
+  def settings
+    return Relay::BaseApp.settings
+  end
+
+  # 出力された JSON 行のうち、指定 event のもの。
+  def records(event = nil)
+    parsed = @log.string.each_line.map {|line| JSON.parse(line)}
+    return event ? parsed.select {|r| r['event'] == event} : parsed
+  end
+
+  def push_once(token:, headers: {})
+    return post(
+      "/push/#{token}", 'encrypted-body',
+      {'CONTENT_TYPE' => 'application/octet-stream'}.merge(headers)
+    )
+  end
+
+  ## request_id
+
+  def test_response_carries_a_request_id
+    get '/health'
+
+    refute_empty(last_response.headers['X-Request-Id'].to_s)
+  end
+
+  # 上流 (nginx) が採番していればそれに乗る。突き合わせの起点を 1 つにするため。
+  def test_upstream_request_id_is_honoured
+    get('/health', {}, {'HTTP_X_REQUEST_ID' => 'from-nginx'})
+
+    assert_equal('from-nginx', last_response.headers['X-Request-Id'])
+  end
+
+  # 1 リクエストの中で id は 1 つ。ログと応答ヘッダが指す先が揃っていないと、
+  # journald ↔ capsicum の Sentry breadcrumb の突き合わせができない。
+  def test_one_id_per_request
+    register_subscription
+
+    ids = records.filter_map {|r| r['request_id']}.uniq
+
+    assert_equal([last_response.headers['X-Request-Id']], ids)
+  end
+
+  def test_request_id_is_logged
+    register_subscription
+
+    assert_equal(
+      last_response.headers['X-Request-Id'], records('register.created').first['request_id']
+    )
+  end
+
+  ## 構造化ログ
+
+  def test_register_emits_a_structured_event
+    register_subscription
+
+    record = records('register.created').first
+
+    assert_equal('ios', record['device_type'])
+    assert_equal('alice@example.test', record['account'])
+    assert_equal('example.test', record['server'])
+    assert_kind_of(Integer, record['latency_ms'])
+  end
+
+  # ⚠ 人間向けの文言を同じ行に残す。docs/CLAUDE.md の grep 手順を壊さない。
+  def test_human_message_is_kept_in_the_same_line
+    register_subscription
+
+    assert_includes(@log.string, 'Registered: alice@example.test (ios')
+  end
+
+  def test_push_received_is_logged_with_encoding
+    parent = register_subscription
+    push_once(token: parent['push_token'], headers: {'HTTP_CONTENT_ENCODING' => 'aes128gcm'})
+
+    record = records('push.received').first
+
+    assert_equal('aes128gcm', record['encoding'])
+    assert_equal('ios', record['device_type'])
+    # jq で数値比較できるよう整数で出す（Rack は String で返す）。
+    assert_equal(14, record['length'])
+  end
+
+  # push_token は capability secret。全部はログに残さない。
+  def test_push_token_is_fingerprinted_not_logged_in_full
+    parent = register_subscription
+    push_once(token: parent['push_token'])
+
+    logged = records('push.received').first['push_token']
+
+    refute_equal(parent['push_token'], logged)
+    assert_includes(@log.string, logged)
+    refute_includes(@log.string, parent['push_token'])
+  end
+
+  def test_push_outcome_is_logged_with_latency
+    parent = register_subscription
+    push_once(token: parent['push_token'])
+    push_once(token: parent['push_token'])
+
+    record = records('push.result').first
+
+    assert_equal('deduped', record['outcome'])
+    assert_kind_of(Integer, record['latency_ms'])
+  end
+
+  ## counter
+
+  def test_register_is_counted
+    register_subscription
+
+    assert_equal(1, settings.metrics.value('relay_register_total', {action: 'created'}))
+  end
+
+  def test_unregister_is_counted
+    sub = register_subscription
+    delete("/register/#{sub['id']}", {}, auth_headers)
+
+    assert_equal(1, settings.metrics.value('relay_register_total', {action: 'deleted'}))
+  end
+
+  def test_supporter_tip_counts_by_amount
+    post_json('/supporters/tip', {account: 'a@b.test', server: 'b.test', count: 3})
+
+    assert_equal(3, settings.metrics.value('relay_supporter_tip_total'))
+  end
+
+  def test_push_outcome_is_counted_by_device_type
+    parent = register_subscription
+    push_once(token: parent['push_token'])
+    push_once(token: parent['push_token'])
+
+    assert_equal(
+      1, settings.metrics.value('relay_push_total', {device_type: 'ios', outcome: 'deduped'})
+    )
+  end
+
+  # 失敗しても計上する（母数が見えないと成功率が出せない・#2 の動機そのもの）。
+  def test_unconfigured_client_is_counted_as_a_push_attempt
+    parent = register_subscription
+    push_once(token: parent['push_token'])
+
+    # クライアント未設定の 503 は dispatch より手前で halt するため outcome は
+    # 付かないが、受信そのものは push.received に残る。
+    assert_equal(503, last_response.status)
+    assert_equal(1, records('push.received').size)
+  end
+
+  ## /metrics
+
+  def test_metrics_requires_secret
+    get '/metrics'
+
+    assert_equal(401, last_response.status)
+  end
+
+  def test_metrics_is_prometheus_text
+    get('/metrics', {}, auth_headers)
+
+    assert_equal(200, last_response.status)
+    assert_match(%r{text/plain}, last_response.headers['content-type'])
+    assert_includes(last_response.body, '# TYPE relay_push_total counter')
+  end
+
+  def test_metrics_exposes_counters
+    register_subscription
+
+    get('/metrics', {}, auth_headers)
+
+    assert_includes(last_response.body, 'relay_register_total{action="created"} 1')
+  end
+
+  # gauge は DB から都度読む。counter と違い再起動をまたいで意味を保つ。
+  def test_metrics_exposes_gauges_from_the_database
+    register_subscription
+
+    get('/metrics', {}, auth_headers)
+
+    assert_includes(last_response.body, "relay_subscriptions 1\n")
+  end
+end

--- a/test/structured_log_test.rb
+++ b/test/structured_log_test.rb
@@ -1,0 +1,78 @@
+require_relative 'test_helper'
+require 'json'
+require 'lib/relay/structured_log'
+
+# 構造化ログの 1 行フォーマット (#2)。
+#
+# ⚠ ヘルパを `format` と名付けない。`Kernel#format` と衝突し、rubocop -a が
+# `Style/RedundantFormat` で `'x' % {...}` に書き換えてテストを壊す（実際に踏んだ）。
+class StructuredLogTest < Minitest::Test
+  TIME = Time.utc(2026, 8, 16, 1, 2, 3)
+
+  def line_for(message, severity: 'INFO')
+    return Relay::StructuredLog::FORMATTER.call(severity, TIME, nil, message)
+  end
+
+  def record_for(message, severity: 'INFO')
+    return JSON.parse(line_for(message, severity: severity))
+  end
+
+  def test_emits_one_json_object_per_line
+    line = line_for('hello')
+
+    assert_equal(1, line.count("\n"))
+    assert(line.end_with?("\n"))
+  end
+
+  def test_includes_timestamp_and_level
+    record = record_for('hello')
+
+    assert_equal('2026-08-16T01:02:03.000Z', record['ts'])
+    assert_equal('INFO', record['level'])
+  end
+
+  # 未計装の呼び出し（logger.info("...")）も JSON になる。
+  def test_string_message_becomes_msg
+    assert_equal('hello', record_for('hello')['msg'])
+  end
+
+  def test_hash_message_is_expanded
+    record = record_for({event: 'push.result', outcome: 'success', latency_ms: 12})
+
+    assert_equal('push.result', record['event'])
+    assert_equal('success', record['outcome'])
+    assert_equal(12, record['latency_ms'])
+  end
+
+  # ⚠ 人間向けの 1 行を捨てない。docs/CLAUDE.md「配信不達の切り分け」の
+  # grep 手順が JSON 化で死なないための条件。
+  def test_human_message_survives_grep
+    line = line_for({event: 'push.result', msg: 'Pushed to windows: a@b'})
+
+    assert_includes(line, 'Pushed to windows: a@b')
+  end
+
+  # nil の項目は落として行を短くする。
+  def test_nil_fields_are_dropped
+    record = record_for({event: 'push.result', latency_ms: nil})
+
+    refute(record.key?('latency_ms'))
+  end
+
+  def test_level_is_taken_from_severity
+    assert_equal('WARN', record_for('x', severity: 'WARN')['level'])
+  end
+
+  # token は capability secret。全部は残さない。
+  def test_fingerprint_masks_the_middle
+    assert_equal('abcdef…wxyz', Relay::StructuredLog.fingerprint('abcdefghijklmnopqrstuvwxyz'))
+  end
+
+  def test_fingerprint_fully_masks_short_tokens
+    assert_equal('*' * 6, Relay::StructuredLog.fingerprint('abcdef'))
+  end
+
+  def test_fingerprint_of_nil_is_nil
+    assert_nil(Relay::StructuredLog.fingerprint(nil))
+  end
+end


### PR DESCRIPTION
Closes #2

relay 側がブラックボックスで、capsicum の Sentry だけでは切り分けられないという積年の課題。issue が挙げている 3 つを入れた。

## 1. 構造化ログ（1 行 = 1 JSON）

```json
{"ts":"2026-08-15T16:02:29.059Z","level":"INFO","event":"push.received",
 "request_id":"2c420a0e-…","msg":"Received push: a@b.test (ios, encoding=\"aes128gcm\" len=4)",
 "device_type":"ios","account":"a@b.test","server":"b.test",
 "push_token":"28a181…0a0c","encoding":"aes128gcm","has_topic":false,"length":4}
```

### ⚠ 人間向けの `msg` を捨てていない

これが設計の肝。[配信不達の切り分け手順](https://github.com/pooza/capsicum-relay/blob/main/docs/CLAUDE.md) は journald を `grep "Pushed to windows:"` する形で回っており、**JSON へ移った瞬間にその手順が死ぬ**。同じ文言を JSON の中に残せば、grep は今までどおり効き、加えて `jq` で集計できる。移行コストを運用側に押し付けないため。

```console
$ journalctl -u capsicum-relay -o cat | grep '"event":"push.result"' \
    | jq -r '[.ts, .device_type, .outcome, .account] | @tsv'
```

### push の結末は出口を 1 つにした

⚠ 従来は結末ごとに `logger` 呼び出しが散っていて、**新しい結末を足すたびに計装を書き忘れる形**だった（WNS の `dropped` が長く件数として見えなかったのがそれ）。`record_push_outcome` を唯一の出口にして、ログと counter を同時に落とす。

`outcome` は `success` / `deduped` / `degraded` / `gone` / `oversized` / `failed` / `wns_<status>`。

### PII の扱い — issue の指定から 1 点ずらした

issue 本文は「account / device の識別子（PII にならないハッシュ化済み値）」と書いているが、**`account` は平文のまま残した**。

- **`push_token` / device token は指紋のみ**。それ自体が capability secret（その端末へ任意の Web Push を投函できる）なので、これは必ず落とす
- **`account` は残す**。journald は flauros 上の非公開ログで、**アカウント単位の不達調査がこのログの主用途**（「この人に届いていない」を成功率で見る手順が docs にある）。ハッシュにすると成立しない

ハッシュに寄せるべきなら戻せます。

## 2. request_id

上流（nginx）の `X-Request-Id` に乗り、無ければ採番。**応答ヘッダ・ログ・Sentry の tag に同じ値**を載せて 3 者を突き合わせられるようにした。

## 3. `/metrics`（Prometheus text exposition）

```
relay_push_total{device_type="ios",outcome="success"} 12
relay_register_total{action="created"} 1
relay_subscriptions 179          # gauge は DB から都度読む
```

14 日ぶんの journald 走査を始める前に、母数と内訳がここで分かる。

- ⚠ **認証必須**。購読数・投げ銭件数は公開する理由が無い（`/health` を無認証にしてあるのは監視用で、あちらは「生きているか」しか出さない）
- ⚠ **counter は in-memory でプロセス再起動でゼロに戻る**。`PushDedup` と同じく puma の `workers 0` 前提に乗っているので、workers を増やすなら両方まとめて共有ストアへ

## 検証

- `rake test` **159 runs / 0 failures**（新規 39 件）・`rubocop` no offenses
- **実起動して実測**: `X-Request-Id` ヘッダ / JSON ログ / **従来の grep が効くこと** / `/metrics` の内容 / 無認証 401

## 踏んだ罠を 1 つ

テストのヘルパを `format` と名付けたら `Kernel#format` と衝突し、`rubocop -a` が `Style/RedundantFormat` で `'x' % {...}` に書き換えて**テストを静かに壊した**。ファイル先頭にコメントで残してある。

## やらなかったこと

issue の 2026-04-23 コメントにある **WebMock による APNs / FCM 応答のモック**は入れていない。request テストの土台自体は #34 で入り、`/push` の route 責務（未知トークンの 410・dedup・未設定時の 503）は覆えている。残るのは「APNs が `BadDeviceToken` を返したとき 410 になり DB 行が消えるか」等の**クライアント応答別の分岐**で、これは `ApnsClient` / `FcmClient` 側のテストとして別に切るのが素直。必要なら起票します。