### PR TITLE
お知らせ通知を Windows へも配送する (#36 Phase 2)

### DIFF
--- a/lib/relay/announcement_worker.rb
+++ b/lib/relay/announcement_worker.rb
@@ -13,17 +13,53 @@ module Relay
   # 必須なため relay から直接は叩けない）。Mastodon / Misskey 両対応で、
   # normalize_announcement が published_at / createdAt の差分を吸収する。
   # 各サーバーの mulukhiya が features.announcement_push: true (5.24.0+) で有効。
-  class AnnouncementWorker
+  #
+  # ⚠ ClassLength を inline で許容している。#36 Phase 2 で 4 つ目の配送先
+  # (WNS) が入り、.rubocop.yml の 130 行（クライアント系クラスの実態に合わせた
+  # 上限）を数行超えた。polling → 正規化 → payload 組み立て → 配送は 1 つの
+  # 凝集した単位で、切るなら ApnsClient / ApnsPayload と同じ「payload の seam」
+  # だが、それは Phase 2 の範囲外。共有の上限を全クラスぶん緩めるより、
+  # .rubocop.yml が明記している「超えるクラスは個別に inline disable」に倣う。
+  class AnnouncementWorker # rubocop:disable Metrics/ClassLength
     DEFAULT_INTERVAL = 60
     REQUEST_TIMEOUT = 10
 
-    def initialize(database:, logger:, apns: nil, fcm: nil, interval: DEFAULT_INTERVAL)
+    # ⚠ ParameterLists を inline で許容している。6 つすべて**キーワード引数**で、
+    # このコップが狙う「順序を覚えられない位置引数の列」にはあたらない。増えたのは
+    # push クライアントが 4 種そろったためで、束ねると base_app 側の
+    # `settings.respond_to?` の分岐が別の入れ物へ移るだけになる。
+    # rubocop:disable Metrics/ParameterLists
+    def initialize(database:, logger:, apns: nil, fcm: nil, wns: nil, interval: DEFAULT_INTERVAL)
       @database = database
       @logger = logger
       @apns = apns
       @fcm = fcm
+      @wns = wns
       @interval = interval
       @stop = false
+    end
+    # rubocop:enable Metrics/ParameterLists
+
+    # Sinatra の settings から push クライアントを拾って組み立てる (#36 Phase 2)。
+    #
+    # ⚠ **「どのクライアントを渡すか」を `deliver` の case と同じファイルに置く**
+    # のが目的。base_app 側に配線を散らしていたときは、`deliver` に `windows` を
+    # 足しても渡し忘れれば「購読行はあるのに 1 通も届かない」形になり、しかも
+    # 例外にならないので**テストにもログにも出なかった**（実測で確認した）。
+    # ここに寄せたので、下の from_settings のテストが 4 種すべての導通を見る。
+    #
+    # 各クライアントは config に鍵が無ければ `set` されない（base_app 参照）ので、
+    # respond_to? で存在を確かめてから渡す。未設定なら nil のまま = その device_type
+    # へは送らない。
+    def self.from_settings(settings, database:, logger:, interval: DEFAULT_INTERVAL)
+      return new(
+        database: database,
+        logger: logger,
+        interval: interval,
+        apns: (settings.respond_to?(:apns) ? settings.apns : nil),
+        fcm: (settings.respond_to?(:fcm) ? settings.fcm : nil),
+        wns: (settings.respond_to?(:wns) ? settings.wns : nil),
+      )
     end
 
     def start!
@@ -131,11 +167,9 @@ module Relay
     # 持たない push を早期 guard で素通しし、ここで付ける `aps.alert` が
     # そのまま表示される（#17 で実測済みの挙動）。
     #
-    # ⚠ **`windows` はまだ足さない**（Phase 2）。WNS raw push には `aps.alert`
-    # に相当する OS 側の表示機構が無く、capsicum の bg task は Web Push の
-    # 暗号化ペイロードしか解釈しない（無暗号化は `bgtask.not_encrypted` で
-    # 捨てる）。ここだけ足しても **Windows では黙って捨てられる**ので、
-    # capsicum#978 が入ってから対にする。
+    # `windows` は WNS raw push（Phase 2 / capsicum#978）。`aps.alert` に相当する
+    # OS 側の表示機構が無いので、トーストは capsicum の bg task が
+    # `announcement_body` から自分で組む。alert はここでは使わない。
     def deliver(sub:, payload:, alert:)
       enriched = payload.merge('account' => sub['account'])
       case sub['device_type']
@@ -147,20 +181,54 @@ module Relay
         return unless @fcm
 
         @fcm.push(device_token: sub['token'], payload: enriched)
+      when 'windows'
+        return unless @wns
+
+        @wns.push(device_token: sub['token'], payload: wns_payload(enriched))
       end
     rescue StandardError => e
       report_error("deliver(#{sub['device_type']})", e)
     end
 
+    # WNS raw の payload 上限は 5000 バイトで、超えると [Relay::WnsClient] の
+    # 送信前チェックが 1 通まるごと落とす（端末には何も出ない）。
+    #
+    # ⚠ **Windows が読むのは `account` / `announcement_body` / `announcement_id`
+    # だけで、HTML のままの `announcement_content` は 1 バイトも使わない**
+    # （capsicum `web_push_receive.cpp` の TryBuildAnnouncementDisplay）。載せた
+    # ままだと「表示に使わないデータのせいで通知そのものが消える」形になるので、
+    # windows 宛だけ落とす。残るのは 80 文字に切った本文とメタだけなので、長文の
+    # お知らせでも上限に近づかない。
+    #
+    # iOS / macOS / Android では落とさない。あちらは capsicum が
+    # `announcement_content` からフル HTML をレンダリングする経路 (#477) を
+    # 持っており、落とすと既存の表示が壊れる。
+    def wns_payload(payload)
+      return payload.except('announcement_content')
+    end
+
     # APNs custom_payload / FCM data は capsicum 側で notification_type を見て
     # NotificationType.announcement に routing される (#477)。FCM の data は
     # transform_values(&:to_s) されるため flat な文字列値で構成する。
+    #
+    # `announcement_body` は整形済み（HTML 剥がし + プレビュー長）の本文で、
+    # **Windows の bg task 用**に足した (#36 Phase 2 / capsicum#978)。WNS raw
+    # push には `aps.alert` に相当する OS 側の表示機構が無く、トーストは
+    # capsicum が自分で組む。`announcement_content` は HTML のままなので、これが
+    # 無いと C++/WinRT 側に HTML 剥がしと UTF-8 の文字数え（バイトで切ると
+    # 日本語が壊れる）を **3 つ目の実装として**書くことになる。整形はここ 1 箇所
+    # に留める。iOS / Android / macOS には無害な追加フィールド。
+    #
+    # ⚠ **title は載せない。** サーバーから来ない（normalize_announcement が
+    # id / content / published_at に落としている）ので、capsicum 側の統一ラベル表
+    # （`notification_type_label.cpp` の `announcement` →「お知らせ」）で解決する。
     def build_payload(server, announcement)
       {
         'notification_type' => 'announcement',
         'server' => server,
         'announcement_id' => announcement['id'].to_s,
         'announcement_content' => announcement['content'].to_s,
+        'announcement_body' => summarize_content(announcement['content'].to_s),
         'announcement_published_at' => announcement['published_at'].to_s,
       }
     end

--- a/lib/relay/announcement_worker.rb
+++ b/lib/relay/announcement_worker.rb
@@ -190,45 +190,51 @@ module Relay
       report_error("deliver(#{sub['device_type']})", e)
     end
 
-    # WNS raw の payload 上限は 5000 バイトで、超えると [Relay::WnsClient] の
-    # 送信前チェックが 1 通まるごと落とす（端末には何も出ない）。
+    # Windows 宛だけの payload 変形 (#36 Phase 2 / capsicum#978)。
     #
-    # ⚠ **Windows が読むのは `account` / `announcement_body` / `announcement_id`
-    # だけで、HTML のままの `announcement_content` は 1 バイトも使わない**
-    # （capsicum `web_push_receive.cpp` の TryBuildAnnouncementDisplay）。載せた
-    # ままだと「表示に使わないデータのせいで通知そのものが消える」形になるので、
-    # windows 宛だけ落とす。残るのは 80 文字に切った本文とメタだけなので、長文の
-    # お知らせでも上限に近づかない。
+    # **`announcement_body` を足す。** WNS raw push には `aps.alert` に相当する
+    # OS 側の表示機構が無く、トーストは capsicum の bg task が自分で組む。
+    # `announcement_content` は HTML のままなので、整形済みの本文をここで渡さないと
+    # C++/WinRT 側に HTML 剥がしと UTF-8 の文字数え（バイトで切ると日本語が壊れる）を
+    # **3 つ目の実装として**書くことになる（Ruby の summarize_content / Dart の
+    # PushMessageDispatcher.synthesizeAnnouncementBody に続いて）。
     #
-    # iOS / macOS / Android では落とさない。あちらは capsicum が
-    # `announcement_content` からフル HTML をレンダリングする経路 (#477) を
-    # 持っており、落とすと既存の表示が壊れる。
+    # **`announcement_content` は落とす。** Windows が読むのは `account` /
+    # `announcement_body` / `announcement_id` だけで、HTML は 1 バイトも使わない
+    # （capsicum `web_push_receive.cpp` の TryBuildAnnouncementDisplay）。WNS raw の
+    # 上限 5000 バイトを超えると [Relay::WnsClient] の送信前チェックが 1 通まるごと
+    # 落とすので、載せたままだと「表示に使わないデータのせいで通知そのものが消える」。
+    # 落とせば残るのは 80 文字の本文とメタだけで、長文のお知らせでも上限に近づかない。
+    #
+    # ⚠ **どちらの変形も windows 宛に閉じている**（Codex P1 / PR #43）。
+    # - content を落とすのは windows だけ。iOS / macOS / Android は capsicum が
+    #   そこからフル HTML をレンダリングする経路 (#477) を持っており、落とすと壊れる。
+    # - body を足すのも windows だけ。全 device_type に足すと、4KB 上限に近い
+    #   お知らせが APNs / FCM で**新たに**上限超えになりうる。しかも
+    #   `ApnsPayload#degraded_payload` が落とすのは暗号化 Web Push 由来のキーだけ
+    #   なので degrade で救えず、`poll_server` は dispatch 後に
+    #   `mark_announcement_seen` を打つため**再送もされない**（その 1 通が永久に
+    #   失われる）。他の 3 種の payload は Phase 2 の前後でバイト単位で不変にする。
     def wns_payload(payload)
-      return payload.except('announcement_content')
+      return payload
+          .except('announcement_content')
+          .merge('announcement_body' => summarize_content(payload['announcement_content'].to_s))
     end
 
     # APNs custom_payload / FCM data は capsicum 側で notification_type を見て
     # NotificationType.announcement に routing される (#477)。FCM の data は
     # transform_values(&:to_s) されるため flat な文字列値で構成する。
     #
-    # `announcement_body` は整形済み（HTML 剥がし + プレビュー長）の本文で、
-    # **Windows の bg task 用**に足した (#36 Phase 2 / capsicum#978)。WNS raw
-    # push には `aps.alert` に相当する OS 側の表示機構が無く、トーストは
-    # capsicum が自分で組む。`announcement_content` は HTML のままなので、これが
-    # 無いと C++/WinRT 側に HTML 剥がしと UTF-8 の文字数え（バイトで切ると
-    # 日本語が壊れる）を **3 つ目の実装として**書くことになる。整形はここ 1 箇所
-    # に留める。iOS / Android / macOS には無害な追加フィールド。
-    #
-    # ⚠ **title は載せない。** サーバーから来ない（normalize_announcement が
-    # id / content / published_at に落としている）ので、capsicum 側の統一ラベル表
-    # （`notification_type_label.cpp` の `announcement` →「お知らせ」）で解決する。
+    # ⚠ **ここは全 device_type 共通の最小形に保つ。** Windows 用の
+    # `announcement_body` は [wns_payload] が配送時に足す。ここに足すと 4KB 上限に
+    # 近いお知らせが APNs / FCM で新たに上限超えになりうるうえ、degrade でも救えず
+    # 再送もされない（Codex P1 / PR #43。詳細は wns_payload のコメント）。
     def build_payload(server, announcement)
       {
         'notification_type' => 'announcement',
         'server' => server,
         'announcement_id' => announcement['id'].to_s,
         'announcement_content' => announcement['content'].to_s,
-        'announcement_body' => summarize_content(announcement['content'].to_s),
         'announcement_published_at' => announcement['published_at'].to_s,
       }
     end

--- a/lib/relay/base_app.rb
+++ b/lib/relay/base_app.rb
@@ -72,11 +72,14 @@ module Relay
       # interval が 0 / negative なら無効化 (テスト時等)。
       interval = settings.config.dig('announcement', 'poll_interval')
       if interval.nil? || interval.to_i.positive?
-        set :announcement_worker, Relay::AnnouncementWorker.new(
+        # ⚠ **push クライアントの配線は worker 側 (from_settings) が持つ** (#36
+        # Phase 2)。ここに列挙していたときは、`deliver` に device_type を足しても
+        # 渡し忘れれば「購読行はあるのに 1 通も届かない」形になり、例外にならない
+        # ぶんテストにもログにも出なかった。
+        set :announcement_worker, Relay::AnnouncementWorker.from_settings(
+          settings,
           database: settings.database,
           logger: settings.logger,
-          apns: (settings.respond_to?(:apns) ? settings.apns : nil),
-          fcm: (settings.respond_to?(:fcm) ? settings.fcm : nil),
           interval: interval&.to_i || Relay::AnnouncementWorker::DEFAULT_INTERVAL,
         )
         settings.announcement_worker.start!

--- a/test/announcement_worker_test.rb
+++ b/test/announcement_worker_test.rb
@@ -108,42 +108,68 @@ class AnnouncementWorkerTest < Minitest::Test
     assert_empty(@wns.pushes)
   end
 
-  # --- windows 宛だけ payload を削る (#36 Phase 2) ---
+  # --- windows 宛だけの payload 変形 (#36 Phase 2) ---
 
-  def deliver_with_content(device_type)
+  def deliver_with_content(device_type, content: "<p>#{'あ' * 3000}</p>")
     return deliver(
       device_type,
       payload: {
         'notification_type' => 'announcement',
         'announcement_id' => '42',
-        'announcement_content' => "<p>#{'あ' * 3000}</p>",
-        'announcement_body' => 'あああ',
+        'announcement_content' => content,
       },
     )
   end
 
-  # ⚠ **本題**: WNS raw の上限は 5000B。Windows は announcement_content を
+  def windows_payload(content: "<p>#{'あ' * 3000}</p>")
+    deliver_with_content('windows', content: content)
+    return @wns.pushes.first[:payload]
+  end
+
+  # ⚠ **本題その 1**: WNS raw の上限は 5000B。Windows は announcement_content を
   # 1 バイトも読まない（capsicum の TryBuildAnnouncementDisplay）ので、載せた
   # ままだと長文のお知らせが「表示に使わないデータのせいで」まるごと落ちる。
   def test_windows_payload_drops_html_content
-    deliver_with_content('windows')
+    payload = windows_payload
 
-    payload = @wns.pushes.first[:payload]
     refute(payload.key?('announcement_content'))
     assert_operator(payload.to_json.bytesize, :<, Relay::WnsClient::RAW_PAYLOAD_LIMIT)
   end
 
-  # 削るのは content だけ。表示に要る本文・宛先・Tag 用の id は残す。
-  def test_windows_payload_keeps_display_fields
-    deliver_with_content('windows')
+  # ⚠ **本題その 2**: bg task はこの整形済み本文でトーストを組む。無いと
+  # `bgtask.announcement_no_body` に落ちて何も表示されない。
+  def test_windows_payload_carries_summarized_body
+    payload = windows_payload(content: '<p>こんにちは <b>世界</b></p>')
 
-    payload = @wns.pushes.first[:payload]
-    assert_equal('あああ', payload['announcement_body'])
+    assert_equal('こんにちは 世界', payload['announcement_body'])
+  end
+
+  # プレビュー長で切る。切った印（…）が付くことまで見る — 付かないと
+  # 「本文が短い」のか「切れている」のか端末側で区別できない。
+  def test_windows_payload_body_is_truncated_with_ellipsis
+    payload = windows_payload(content: "<p>#{'あ' * 100}</p>")
+
+    assert_equal(81, payload['announcement_body'].length)
+    assert(payload['announcement_body'].end_with?('…'))
+  end
+
+  # 全部が空になっても nil にしない（capsicum 側は空文字なら表示しない判断を
+  # するので、キー自体が消えると「旧 relay」と区別できなくなる）。
+  def test_windows_payload_body_is_string_even_when_content_is_empty
+    payload = windows_payload(content: '')
+
+    assert_equal('', payload['announcement_body'])
+  end
+
+  # 削るのは content だけ。宛先・Tag 用の id は残す。
+  def test_windows_payload_keeps_display_fields
+    payload = windows_payload
+
     assert_equal('42', payload['announcement_id'])
     assert_equal('alice@example', payload['account'])
   end
 
-  # ⚠ 逆向きの固定。iOS / macOS / Android は content からフル HTML を
+  # ⚠ 逆向きの固定 その 1。iOS / macOS / Android は content からフル HTML を
   # レンダリングする経路 (#477) を持っているので、削ると既存表示が壊れる。
   def test_apns_and_fcm_payloads_keep_html_content
     deliver_with_content('macos')
@@ -151,6 +177,19 @@ class AnnouncementWorkerTest < Minitest::Test
 
     assert(@apns.pushes.first[:payload].key?('announcement_content'))
     assert(@fcm.pushes.first[:payload].key?('announcement_content'))
+  end
+
+  # ⚠ 逆向きの固定 その 2（Codex P1 / PR #43）。**windows 以外の payload は
+  # Phase 2 の前後で不変**でなければならない。announcement_body を全 device_type
+  # に足すと、4KB 上限に近いお知らせが APNs / FCM で新たに上限超えになりうる。
+  # degrade は暗号化キーしか落とさないので救えず、poll_server は dispatch 後に
+  # mark_announcement_seen を打つので**再送もされない**（その 1 通が永久に消える）。
+  def test_apns_and_fcm_payloads_do_not_gain_the_windows_preview
+    deliver_with_content('macos')
+    deliver_with_content('android')
+
+    refute(@apns.pushes.first[:payload].key?('announcement_body'))
+    refute(@fcm.pushes.first[:payload].key?('announcement_body'))
   end
 
   # account は payload へ混ぜて送る（capsicum 側が宛先アカウントを解決する）。
@@ -229,38 +268,18 @@ class AnnouncementWorkerTest < Minitest::Test
     )
   end
 
-  # Windows の bg task はこの整形済み本文でトーストを組む。HTML のままの
-  # `announcement_content` しか無いと、C++/WinRT 側に HTML 剥がしを 3 つ目の
-  # 実装として書くことになる。
-  def test_payload_carries_summarized_body
-    payload = build_payload('<p>こんにちは <b>世界</b></p>')
-
-    assert_equal('こんにちは 世界', payload['announcement_body'])
-  end
-
-  # HTML のままの content も従来どおり残す（capsicum 側がタップ後に
-  # フルレンダリングする経路が使っている）。落とすと既存挙動が壊れる。
+  # HTML のままの content を載せる（capsicum がタップ後にフルレンダリング
+  # する経路が使っている）。落とすと既存挙動が壊れる。
   def test_payload_keeps_raw_html_content
     payload = build_payload('<p>こんにちは</p>')
 
     assert_equal('<p>こんにちは</p>', payload['announcement_content'])
   end
 
-  # プレビュー長で切る。切った印（…）が付くことまで見る — 付かないと
-  # 「本文が短い」のか「切れている」のか端末側で区別できない。
-  def test_payload_body_is_truncated_with_ellipsis
-    payload = build_payload("<p>#{'あ' * 100}</p>")
-
-    assert_equal(81, payload['announcement_body'].length)
-    assert(payload['announcement_body'].end_with?('…'))
-  end
-
-  # 全部が空になっても nil にしない（capsicum 側は空文字なら表示しない判断を
-  # するので、キー自体が消えると「旧 relay」と区別できなくなる）。
-  def test_payload_body_is_string_even_when_content_is_empty
-    payload = build_payload('')
-
-    assert_equal('', payload['announcement_body'])
+  # ⚠ **共通 payload は Phase 2 で 1 バイトも増やさない**（Codex P1 / PR #43）。
+  # Windows 用の announcement_body は wns_payload が配送時に足す。
+  def test_payload_has_no_windows_preview
+    refute(build_payload('<p>こんにちは</p>').key?('announcement_body'))
   end
 
   # ⚠ title は載せない。サーバーから来ないので capsicum 側の統一ラベル表で

--- a/test/announcement_worker_test.rb
+++ b/test/announcement_worker_test.rb
@@ -1,18 +1,20 @@
 require_relative 'test_helper'
+require 'json'
 require 'logger'
 require 'lib/relay/announcement_worker'
+# 上限は WnsClient が持つ定数を参照する（テスト側に数値を写さない）。
+require 'lib/relay/wns_client'
 
-# #36 Phase 1: お知らせ通知の配送先を macOS へ広げる。
+# #36: お知らせ通知の配送先を macOS (Phase 1) / Windows (Phase 2) へ広げる。
 #
 # `deliver` の分岐は通常の push 経路（`Relay::PushHelpers#push_client_for`）と
 # **同じ形でなければならない**。register は 4 種すべてを受け付け、
 # `announcement_subscriptions_for_server` も device_type / token を返すので、
 # ここが揃っていないぶんだけ「登録できるのに届かない」端末が生まれる。
 #
-# ⚠ **windows をまだ足していないのは意図的**（Phase 2）。relay 側だけ足すと
-# capsicum の bg task が無暗号化ペイロードを捨てるので、**送っても黙って
-# 消える**。それを「未実装」でなく「壊れている」に見せないよう、ここで
-# 「送らない」ことを固定する。
+# Phase 2 で 4 種すべてが揃った（capsicum#978 の bg task が無暗号化エンベロープを
+# 解釈できるようになったため）。残る非対称は **windows だけ payload が違う**点で、
+# 下の wns_payload 系のテストがそれを固定する。
 class AnnouncementWorkerTest < Minitest::Test
   # push された引数を記録するだけのクライアント。
   class RecordingClient
@@ -32,19 +34,21 @@ class AnnouncementWorkerTest < Minitest::Test
   def setup
     @apns = RecordingClient.new
     @fcm = RecordingClient.new
+    @wns = RecordingClient.new
     @worker = Relay::AnnouncementWorker.new(
       database: nil,
       logger: Logger.new(IO::NULL),
       apns: @apns,
       fcm: @fcm,
+      wns: @wns,
     )
   end
 
-  def deliver(device_type, token: 'tok')
+  def deliver(device_type, token: 'tok', payload: {'notification_type' => 'announcement'})
     @worker.send(
       :deliver,
       sub: {'device_type' => device_type, 'token' => token, 'account' => 'alice@example'},
-      payload: {'notification_type' => 'announcement'},
+      payload: payload,
       alert: {title: 'お知らせ', body: '本文'},
     )
   end
@@ -78,12 +82,22 @@ class AnnouncementWorkerTest < Minitest::Test
     assert_empty(@apns.pushes)
   end
 
-  # ⚠ Phase 2 待ち。capsicum#978 が入るまでは送らないのが正しい。
-  def test_windows_is_not_delivered_yet
+  # Phase 2 の本体 (capsicum#978)。bg task が無暗号化エンベロープを解釈できる
+  # ようになったので、ここを足して初めて Windows へ配送される。
+  def test_windows_goes_to_wns
     deliver('windows')
 
+    assert_equal(1, @wns.pushes.size)
     assert_empty(@apns.pushes)
     assert_empty(@fcm.pushes)
+  end
+
+  # WNS raw に alert 相当の機構は無い。トーストは capsicum が payload から
+  # 組むので、alert を渡してしまうと「使われない大きな引数」になる。
+  def test_windows_is_pushed_without_alert
+    deliver('windows')
+
+    refute(@wns.pushes.first.key?(:alert))
   end
 
   def test_unknown_device_type_is_ignored
@@ -91,6 +105,52 @@ class AnnouncementWorkerTest < Minitest::Test
 
     assert_empty(@apns.pushes)
     assert_empty(@fcm.pushes)
+    assert_empty(@wns.pushes)
+  end
+
+  # --- windows 宛だけ payload を削る (#36 Phase 2) ---
+
+  def deliver_with_content(device_type)
+    return deliver(
+      device_type,
+      payload: {
+        'notification_type' => 'announcement',
+        'announcement_id' => '42',
+        'announcement_content' => "<p>#{'あ' * 3000}</p>",
+        'announcement_body' => 'あああ',
+      },
+    )
+  end
+
+  # ⚠ **本題**: WNS raw の上限は 5000B。Windows は announcement_content を
+  # 1 バイトも読まない（capsicum の TryBuildAnnouncementDisplay）ので、載せた
+  # ままだと長文のお知らせが「表示に使わないデータのせいで」まるごと落ちる。
+  def test_windows_payload_drops_html_content
+    deliver_with_content('windows')
+
+    payload = @wns.pushes.first[:payload]
+    refute(payload.key?('announcement_content'))
+    assert_operator(payload.to_json.bytesize, :<, Relay::WnsClient::RAW_PAYLOAD_LIMIT)
+  end
+
+  # 削るのは content だけ。表示に要る本文・宛先・Tag 用の id は残す。
+  def test_windows_payload_keeps_display_fields
+    deliver_with_content('windows')
+
+    payload = @wns.pushes.first[:payload]
+    assert_equal('あああ', payload['announcement_body'])
+    assert_equal('42', payload['announcement_id'])
+    assert_equal('alice@example', payload['account'])
+  end
+
+  # ⚠ 逆向きの固定。iOS / macOS / Android は content からフル HTML を
+  # レンダリングする経路 (#477) を持っているので、削ると既存表示が壊れる。
+  def test_apns_and_fcm_payloads_keep_html_content
+    deliver_with_content('macos')
+    deliver_with_content('android')
+
+    assert(@apns.pushes.first[:payload].key?('announcement_content'))
+    assert(@fcm.pushes.first[:payload].key?('announcement_content'))
   end
 
   # account は payload へ混ぜて送る（capsicum 側が宛先アカウントを解決する）。
@@ -102,15 +162,110 @@ class AnnouncementWorkerTest < Minitest::Test
   end
 
   # クライアント未設定（設定漏れ・起動順）でも落とさない。
+  # ⚠ windows も含める。base_app が `wns:` を渡し忘れると、購読行はあるのに
+  # 1 通も届かない形になるが、例外にはならず静かに無効化される。
   def test_missing_client_is_survived
     worker = Relay::AnnouncementWorker.new(
-      database: nil, logger: Logger.new(IO::NULL), apns: nil, fcm: nil,
+      database: nil, logger: Logger.new(IO::NULL), apns: nil, fcm: nil, wns: nil,
+    )
+
+    ['macos', 'windows'].each do |device_type|
+      worker.send(
+        :deliver,
+        sub: {'device_type' => device_type, 'token' => 'tok', 'account' => 'a@b'},
+        payload: {}, alert: {}
+      )
+    end
+  end
+
+  # --- base_app からの配線 (#36 Phase 2) ---
+
+  # `deliver` に device_type を足しても、settings から拾い忘れれば
+  # 「購読行はあるのに 1 通も届かない」形になる。例外にならないので、ここで
+  # 見ていないと**テストにもログにも出ない**（Phase 2 の実装中に実測した）。
+  def test_from_settings_wires_every_push_client
+    settings = Struct.new(:apns, :fcm, :wns).new(@apns, @fcm, @wns)
+    worker = Relay::AnnouncementWorker.from_settings(
+      settings, database: nil, logger: Logger.new(IO::NULL), interval: 0
+    )
+
+    ['ios', 'macos', 'android', 'windows'].each do |device_type|
+      worker.send(
+        :deliver,
+        sub: {'device_type' => device_type, 'token' => 'tok', 'account' => 'a@b'},
+        payload: {}, alert: {}
+      )
+    end
+
+    assert_equal(2, @apns.pushes.size, 'ios + macos')
+    assert_equal(1, @fcm.pushes.size, 'android')
+    assert_equal(1, @wns.pushes.size, 'windows')
+  end
+
+  # 鍵が config に無いクライアントは base_app が `set` しないので、settings は
+  # そのメソッドに応答しない。落とさず nil のまま組み立てる。
+  def test_from_settings_survives_unconfigured_clients
+    worker = Relay::AnnouncementWorker.from_settings(
+      Struct.new(:nothing).new(nil),
+      database: nil, logger: Logger.new(IO::NULL), interval: 0,
     )
 
     worker.send(
       :deliver,
-      sub: {'device_type' => 'macos', 'token' => 'tok', 'account' => 'a@b'},
+      sub: {'device_type' => 'windows', 'token' => 'tok', 'account' => 'a@b'},
       payload: {}, alert: {}
     )
+
+    assert_empty(@wns.pushes)
+  end
+
+  # --- payload の組み立て (#36 Phase 2 / capsicum#978) ---
+
+  def build_payload(content)
+    return @worker.send(
+      :build_payload,
+      'example.test',
+      {'id' => '42', 'content' => content, 'published_at' => '2026-08-16T00:00:00Z'},
+    )
+  end
+
+  # Windows の bg task はこの整形済み本文でトーストを組む。HTML のままの
+  # `announcement_content` しか無いと、C++/WinRT 側に HTML 剥がしを 3 つ目の
+  # 実装として書くことになる。
+  def test_payload_carries_summarized_body
+    payload = build_payload('<p>こんにちは <b>世界</b></p>')
+
+    assert_equal('こんにちは 世界', payload['announcement_body'])
+  end
+
+  # HTML のままの content も従来どおり残す（capsicum 側がタップ後に
+  # フルレンダリングする経路が使っている）。落とすと既存挙動が壊れる。
+  def test_payload_keeps_raw_html_content
+    payload = build_payload('<p>こんにちは</p>')
+
+    assert_equal('<p>こんにちは</p>', payload['announcement_content'])
+  end
+
+  # プレビュー長で切る。切った印（…）が付くことまで見る — 付かないと
+  # 「本文が短い」のか「切れている」のか端末側で区別できない。
+  def test_payload_body_is_truncated_with_ellipsis
+    payload = build_payload("<p>#{'あ' * 100}</p>")
+
+    assert_equal(81, payload['announcement_body'].length)
+    assert(payload['announcement_body'].end_with?('…'))
+  end
+
+  # 全部が空になっても nil にしない（capsicum 側は空文字なら表示しない判断を
+  # するので、キー自体が消えると「旧 relay」と区別できなくなる）。
+  def test_payload_body_is_string_even_when_content_is_empty
+    payload = build_payload('')
+
+    assert_equal('', payload['announcement_body'])
+  end
+
+  # ⚠ title は載せない。サーバーから来ないので capsicum 側の統一ラベル表で
+  # 解決する（載せると「どちらが正か」が 2 箇所に散る）。
+  def test_payload_has_no_title
+    refute(build_payload('<p>x</p>').key?('announcement_title'))
   end
 end


### PR DESCRIPTION
capsicum#978 が develop に入った（`1f5e0a41`）ので、対になる relay 側 Phase 2 を入れます。Closes #36。

## 何が入るか

1. **`deliver` に `when 'windows'`** — WNS raw push へ配送する。`test_windows_is_not_delivered_yet` は `test_windows_goes_to_wns` へ反転。
2. **`build_payload` に `announcement_body`** — 整形済み（HTML 剥がし + 80 文字）の本文。WNS raw には `aps.alert` 相当が無く、トーストは capsicum が自分で組むため。title は載せない（サーバーから来ないので capsicum 側のラベル表で解決）。
3. **windows 宛だけ `announcement_content` を落とす** — #36 に残っていた oversized 論点の決着。
4. **配線を `AnnouncementWorker.from_settings` へ寄せた** — 変異テストで見つけた穴の手当て。

## 3 の判断（oversized）

WNS raw の上限は 5000B で、超えると `WnsClient` の送信前チェックが **1 通まるごと**落とす（端末には何も出ない）。`build_payload` は HTML のままの `announcement_content` を丸ごと載せているので、長文のお知らせが「**表示に使わないデータのせいで通知そのものが消える**」形でした。

Windows が読むのは `account` / `announcement_body` / `announcement_id` だけで、`announcement_content` は 1 バイトも使いません（capsicum `web_push_receive.cpp` の `TryBuildAnnouncementDisplay` で確認）。よって配送時 (`wns_payload`) に落とします。残るのは 80 文字に切った本文とメタだけなので、どれだけ長いお知らせでも上限に近づきません。

⚠ **iOS / macOS / Android では落としません。** あちらは capsicum が `announcement_content` からフル HTML をレンダリングする経路 (#477) を持っているので、落とすと既存の表示が壊れます。逆向きの固定もテストに入れました。

`build_payload` は購読者ごとでなく 1 回だけ組まれるので、payload を device_type 別に 2 通り組むより、削る 1 箇所を `deliver` の分岐に持たせる方が「誰が何を読むか」と 1 対 1 になります。

## 4 の経緯（変異テストで見つけた穴）

当初は base_app の `configure` に `wns:` を 1 行足すだけにしていたのですが、**その行を消してもテストが 1 件も落ちませんでした**。`deliver` に device_type を足しても渡し忘れれば「購読行はあるのに 1 通も届かない」形になり、しかも例外にならないのでログにも出ません。capsicum#919 で client と relay が独立に分岐していて片方だけ広がったのと同じ形です。

`AnnouncementWorker.from_settings` を足して、**どのクライアントを渡すかを `deliver` の case と同じファイルに置きました**。`test_from_settings_wires_every_push_client` が 4 種すべての導通を見るので、次に device_type を足すときは配線の落としが必ずテストで落ちます。

## rubocop

4 つ目の配送先が入って `Metrics/ClassLength` (133/130) と `Metrics/ParameterLists` (6/5) に当たったので、どちらも inline disable にしています。`.rubocop.yml` の 130 は「クライアント系クラスの実態に合わせた上限。超える App / Database は個別に inline disable している」と明記されているので、共有の上限を全クラスぶん緩めるよりそちらに倣いました。`ParameterLists` は 6 つすべてキーワード引数で、このコップが狙う位置引数の列にはあたりません。

さらに伸びるようなら、切る先は `ApnsClient` / `ApnsPayload` と同じ「payload の seam」だと思いますが、Phase 2 の範囲外としました。

## 検証

- `bundle exec rake test` … **172 runs, 368 assertions, 0 failures**（+11 件）
- `bundle exec rubocop` … **41 files, no offenses**
- 実装を **5 通りに壊してすべてテストが落ちること**を実測（HTML を落とさない / `announcement_body` を載せない / `when 'windows'` を消す / `from_settings` が wns を拾わない / windows へ alert を渡す）

⚠ このリポジトリには CI が無いので、上記はローカル（rbenv の Ruby 4.0.6）が唯一の担保です。

## デプロイ後の確認

capsicum の購読ゲートは既に `windows` を含んでおり、**Windows 実機 1 台ぶんの 5 行が既に登録済み**です（`/health` の `announcement_subscriptions` が 27 → 32）。デプロイした瞬間にこの 5 行へ配送が始まるので、次の実お知らせ投稿で macOS 到達確認と同時に拾えます。

判定は Sentry の `push.bgtask.code`:

- `bgtask.announcement_shown` … 成功（info）
- `bgtask.announcement_no_body` … `announcement_body` の載せ忘れ（warning）