### PR TITLE
docs: v1.57 で得た配線の変異テストと Ruby 作業端末の規約を残す

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -146,6 +146,22 @@ erDiagram
 - Sinatra の `configure do` / `helpers do` はメソッド定義を束ねるブロックであり、行数で括らない。`Metrics/BlockLength` の `AllowedMethods` に追加してある
 - Sinatra の route ブロック（`get '/xxx' do ... end`）の最終値は暗黙 return のままにする。`return` はブロック内でエンクロージングメソッドからの return になるため使わない。途中離脱は `halt` を使う
 
+## テスト
+
+**本リポジトリに CI は無い。**`bundle exec rake test` と `bundle exec rubocop` をローカルで通すことが唯一の担保になる。
+
+### 配信の「配線」を足したら変異テストを回す
+
+device_type やクライアントの対応を広げる変更（`AnnouncementWorker#deliver` の `case`、`PushHelpers#push_client_for` の分岐、payload 組み立ての分岐など）は、**足した行を消してもテストが 1 件も落ちない**形になりやすい。購読行はあるのに 1 通も届かず、例外にならないのでログにも出ないためで、[#36](https://github.com/pooza/capsicum-relay/issues/36) Phase 2 で実際に踏んだ（capsicum 側の同型は pooza/capsicum#919）。
+
+- 配線を足したら、**その行を 1 つずつ壊してテストが落ちることを確認する**。落ちなければテストが配線を見ていない
+- 「どのクライアントを渡すか」の決定を `deliver` の `case` と同じファイルに寄せ（`AnnouncementWorker.from_settings` がその形）、device_type ごとの導通テストを持たせる
+- ⚠ 変異テストで `git checkout <file>` を使うと**未コミットの実装ごと巻き戻る**。壊す前にコミットしておくこと
+
+### Ruby の作業は macOS 端末で行う
+
+Windows 実機（capsicum の Windows 機能検証機）に Ruby を入れて `rake test` を回す案は採らない。**`Gemfile.lock` に Windows プラットフォームの行が載り、端末間で往復する**ため（capsicum の `pubspec.lock` ping-pong と同型）。Windows 側で relay の変更が必要になったときは、差分を Issue のコメントに置いて macOS 端末へ引き継ぐ。
+
 ## インフラ
 
 | 項目 | 値 |


### PR DESCRIPTION
capsicum の v1.57 マイルストーン後片付けで、GitHub Issue / PR にしか残っていなかった知見を `docs/CLAUDE.md` へ昇格させた。コード変更なし。

- **配線を足したら変異テストを回す** … `AnnouncementWorker#deliver` の `case` のような配線は「足した行を消してもテストが 1 件も落ちない」形になりやすく、#36 Phase 2 で実際に踏んだ。壊して落ちることを確認する手順と、`git checkout <file>` が未コミットの実装ごと巻き戻す罠を明記。
- **Ruby の作業は macOS 端末で** … Windows 実機に Ruby を入れると `Gemfile.lock` に Windows プラットフォームが載って端末間で往復する。

あわせて「本リポジトリに CI は無く `rake test` / `rubocop` のローカル実行が唯一の担保」を節の冒頭に明示した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)