### PR TITLE
401 で弾いたことを構造化ログに残す (#47)

### DIFF
--- a/lib/relay/base_app.rb
+++ b/lib/relay/base_app.rb
@@ -103,10 +103,39 @@ module Relay
     helpers Relay::PushHelpers
 
     helpers do
+      # 共有シークレットによる認証 (#47)。
+      #
+      # ⚠ **弾いたことを必ずログに残す。** 以前は無言で halt しており、
+      # サーバー側から「リクエストが来ていない」と「来たが弾いた」を区別できな
+      # かった。2026-08-18 に staging の journald が空なのを見て「クライアントが
+      # 投げていない」と誤診している（実際は capsicum の debug ビルドが
+      # `--dart-define=RELAY_SECRET` 無しでビルドされ、空の secret を送っていた。
+      # pooza/capsicum#994）。原因はまったく別（向け先 / 資格情報）なので、
+      # ここが無音だと切り分けが端末側の画面頼みになる。
+      #
+      # ⚠ **secret そのものは絶対に出さない。**残すのは `missing`（ヘッダが無い
+      # / 空）か `mismatch`（値が違う）かの 2 値だけ。この区別に意味がある —
+      # `missing` はビルド時に値を渡し忘れた形、`mismatch` は値が古い形で、
+      # 対処が違う。
       def authenticate!
         secret = settings.config['shared_secret']
         provided = request.env['HTTP_X_RELAY_SECRET']
-        halt 401, {error: 'Unauthorized'}.to_json unless provided == secret
+        return if provided == secret
+
+        log_auth_rejected(provided)
+        halt 401, {error: 'Unauthorized'}.to_json
+      end
+
+      def log_auth_rejected(provided)
+        reason = provided.to_s.empty? ? 'missing' : 'mismatch'
+        log_event(
+          'auth.rejected',
+          level: :warn,
+          msg: "Rejected unauthenticated request: #{request.path_info} (#{reason})",
+          reason: reason,
+          path: request.path_info,
+          method: request.request_method,
+        )
       end
 
       def json_body

--- a/lib/relay/base_app.rb
+++ b/lib/relay/base_app.rb
@@ -128,14 +128,31 @@ module Relay
 
       def log_auth_rejected(provided)
         reason = provided.to_s.empty? ? 'missing' : 'mismatch'
+        path = redacted_path
         log_event(
           'auth.rejected',
           level: :warn,
-          msg: "Rejected unauthenticated request: #{request.path_info} (#{reason})",
+          msg: "Rejected unauthenticated request: #{path} (#{reason})",
           reason: reason,
-          path: request.path_info,
+          path: path,
           method: request.request_method,
         )
+      end
+
+      # ⚠ **`path_info` をそのまま残さない** (PR #48 の Codex P1)。
+      # `/push/:push_token` と `/announcement_subscriptions/:push_token` は
+      # **path 自体に capability secret が載る**。[Relay::StructuredLog.fingerprint]
+      # が push_token を指紋にしているのと同じ理由で、ここも生では出せない。
+      #
+      # 先頭セグメントだけ残せば「どのエンドポイントが弾かれたか」という切り分けに
+      # 要る情報は保てる。⚠ **allow-list ではなく既定で落とす形にするのが要点。**
+      # route が増えたときに自動で安全側へ倒れる（`/supporters/tip` のように可変部が
+      # 無い 2 段の route も畳まれるが、`method` で区別できる）。
+      def redacted_path
+        head = request.path_info.to_s.split('/')[1].to_s
+        return '/' if head.empty?
+
+        return request.path_info.to_s.count('/') > 1 ? "/#{head}/…" : "/#{head}"
       end
 
       def json_body

--- a/test/observability_route_test.rb
+++ b/test/observability_route_test.rb
@@ -215,4 +215,61 @@ class ObservabilityRouteTest < RequestTestCase
 
     assert_includes(last_response.body, "relay_subscriptions 1\n")
   end
+
+  ## 認証の拒否 (#47)
+
+  # 以前は無言で halt しており、サーバー側から「リクエストが来ていない」と
+  # 「来たが弾いた」を区別できなかった。2026-08-18 に staging の journald が
+  # 空なのを見て「クライアントが投げていない」と誤診している (capsicum#994)。
+  def test_rejected_request_is_logged
+    get '/metrics'
+
+    assert_equal(401, last_response.status)
+    refute_empty(records('auth.rejected'), '401 がログに残っていない')
+  end
+
+  # ⚠ ヘッダ欠落と値違いを区別する。missing はビルド時に値を渡し忘れた形
+  # (capsicum#994 がこれ)、mismatch は値が古い形で、対処が違う。
+  def test_missing_secret_is_distinguished_from_a_wrong_one
+    get '/metrics'
+    assert_equal('missing', records('auth.rejected').last['reason'])
+
+    get('/metrics', {}, {'HTTP_X_RELAY_SECRET' => 'not-the-secret'})
+    assert_equal('mismatch', records('auth.rejected').last['reason'])
+  end
+
+  # 空文字は「送っていない」と同じ扱い。ヘッダの有無で分けると、空値を送って
+  # くるクライアント (dart-define が空のまま焼き込まれた形) が mismatch 側へ
+  # 落ちて、原因の読み違いにつながる。
+  def test_empty_secret_counts_as_missing
+    get('/metrics', {}, {'HTTP_X_RELAY_SECRET' => ''})
+
+    assert_equal('missing', records('auth.rejected').last['reason'])
+  end
+
+  # ⚠ secret そのものは絶対に残さない。
+  def test_rejection_log_never_contains_the_secret
+    get('/metrics', {}, {'HTTP_X_RELAY_SECRET' => 'super-secret-value'})
+
+    refute_includes(@log.string, 'super-secret-value')
+    refute_includes(@log.string, SECRET)
+  end
+
+  # 切り分けに要るのは「どのエンドポイントが弾かれたか」。
+  def test_rejection_log_carries_the_path
+    get '/metrics'
+
+    record = records('auth.rejected').last
+    assert_equal('/metrics', record['path'])
+    assert_equal('GET', record['method'])
+    refute_empty(record['request_id'].to_s)
+  end
+
+  # 通ったリクエストでは出さない（正常系がログを埋めない）。
+  def test_authorised_request_is_not_logged_as_rejected
+    get('/metrics', {}, auth_headers)
+
+    assert_equal(200, last_response.status)
+    assert_empty(records('auth.rejected'))
+  end
 end

--- a/test/observability_route_test.rb
+++ b/test/observability_route_test.rb
@@ -265,6 +265,36 @@ class ObservabilityRouteTest < RequestTestCase
     refute_empty(record['request_id'].to_s)
   end
 
+  # ⚠ path 自体に capability secret が載る route がある
+  # (`/push/:push_token` / `/announcement_subscriptions/:push_token`)。
+  # StructuredLog.fingerprint が push_token を指紋にしているのと同じ理由で、
+  # ここも生では出せない (PR #48 の Codex P1)。
+  #
+  # ⚠ `POST /push/:push_token` は **authenticate! を通らない**（送り手は shared
+  # secret を知らない Mastodon / Misskey サーバー）ので、この経路には来ない。
+  # 認証が要るのは register / announcement_subscriptions / supporters / metrics。
+  def test_rejection_log_redacts_the_token_in_the_path
+    get '/announcement_subscriptions/super-secret-push-token'
+
+    assert_equal(401, last_response.status)
+    refute_includes(@log.string, 'super-secret-push-token')
+    assert_equal('/announcement_subscriptions/…', records('auth.rejected').last['path'])
+  end
+
+  # id も同様に落とす（誰の subscription を消そうとしたかを残さない）。
+  def test_rejection_log_redacts_ids_too
+    delete '/register/12345'
+
+    assert_equal('/register/…', records('auth.rejected').last['path'])
+  end
+
+  # 可変部の無い route は畳まない。畳むとどのエンドポイントか分からなくなる。
+  def test_rejection_log_keeps_single_segment_paths_intact
+    post '/register'
+
+    assert_equal('/register', records('auth.rejected').last['path'])
+  end
+
   # 通ったリクエストでは出さない（正常系がログを埋めない）。
   def test_authorised_request_is_not_logged_as_rejected
     get('/metrics', {}, auth_headers)


### PR DESCRIPTION
Closes #47

## 背景

`authenticate!` が無言で `halt` しており、サーバー側から**「リクエストが来ていない」と「来たが弾いた」を区別できなかった**。

2026-08-18 に実害が出た。capsicum の macOS debug ビルドでプッシュが動かない件（pooza/capsicum#994）を追うのに staging の journald を見たところ、Puma の起動バナー以外 1 行も無く、**「クライアントが投げていない」と誤診した**。実際には `--dart-define=RELAY_SECRET` 無しでビルドされた debug アプリが空の secret を送っており、ここで黙って弾かれていた。

原因はまったく別（向け先 / 資格情報）なので、無音だと切り分けが端末側の画面頼みになる。

## 変更

`event=auth.rejected` を `level=warn` で 1 行出す。`path` / `method` / `request_id` 付き。

```json
{"ts":"...","level":"WARN","event":"auth.rejected","request_id":"...","msg":"Rejected unauthenticated request: /register (missing)","reason":"missing","path":"/register","method":"POST"}
```

- ⚠ **secret そのものは出さない。**残すのは `missing` / `mismatch` の 2 値だけ。`missing` はビルド時に値を渡し忘れた形（今回がこれ）、`mismatch` は値が古い形で、**対処が違う**
- **空文字は `missing` 扱い。**ヘッダの有無で分けると、空値を送るクライアント（dart-define が空のまま焼き込まれた形）が `mismatch` へ落ちて読み違える
- 正常系では出さない

Sentry へは上げていない。総当たりを受けたときにノイズになるため、まずはログだけ（#47 本文の判断）。

## テスト

`bundle exec rake test` 180 runs / 387 assertions / 0 failures、`bundle exec rubocop` 41 files / no offenses。

**変異テストを回した**（docs/CLAUDE.md「配信の『配線』を足したら変異テストを回す」）。3 通り壊して、いずれもテストが落ちることを確認:

| 壊し方 | 結果 |
|---|---|
| `log_auth_rejected` の呼び出しを消す | 1 failure + 3 errors |
| `reason` を常に `mismatch` にする | 2 failures |
| `path` を落とす | 1 failure |