### PR TITLE
chore: RuboCop 設定を ginseng-style へ寄せる (#49)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,130 +1,17 @@
-plugins:
-  - rubocop-performance
+# 正本は pooza/ginseng-style の config/rubocop.yml。ここには capsicum-relay 固有の差分だけを書く。
+# ⚠ 共通に見える緩和をここに足さないこと。共通化したい場合は pooza/ginseng-style に Issue を立てる。
+# ⚠ `bundle exec rubocop` で実行すること（inherit_gem は gem のパス解決に Bundler を使う）。
+inherit_gem:
+  ginseng-style: config/rubocop.yml
 
 AllCops:
-  AllowSymlinksInCacheRootDirectory: true
-  DisplayCopNames: true
-  Exclude:
-    - '**/._*'
-    - '**/.git/**/*'
-    - config/**/*
-    - tmp/**/*
-    - '**/old/**/*'
-  Include:
-    - '**/*.rb'
-    - '**/Rakefile'
-    - '**/config.ru'
-  NewCops: enable
   TargetRubyVersion: 4.0
-Layout/ArgumentAlignment:
-  EnforcedStyle: with_fixed_indentation
-Layout/ArrayAlignment:
-  EnforcedStyle: with_fixed_indentation
-Layout/EmptyLineAfterGuardClause:
-  Enabled: false
-Layout/EndAlignment:
-  EnforcedStyleAlignWith: variable
-Layout/EndOfLine:
-  EnforcedStyle: lf
-Layout/FirstArgumentIndentation:
-  EnforcedStyle: consistent
-Layout/FirstArrayElementIndentation:
-  EnforcedStyle: consistent
-Layout/FirstHashElementIndentation:
-  EnforcedStyle: consistent
-Layout/LineContinuationLeadingSpace:
-  EnforcedStyle: leading
-Layout/LineEndStringConcatenationIndentation:
-  EnforcedStyle: indented
-Layout/LineLength:
-  Exclude:
-    - test/**/*
-  Max: 100
-Layout/MultilineMethodCallIndentation:
-  EnforcedStyle: indented
-Layout/MultilineOperationIndentation:
-  EnforcedStyle: indented
-Layout/ParameterAlignment:
-  EnforcedStyle: with_fixed_indentation
-Layout/SpaceBeforeBlockBraces:
-  EnforcedStyle: space
-Layout/SpaceInsideBlockBraces:
-  EnforcedStyle: no_space
-  EnforcedStyleForEmptyBraces: no_space
-  SpaceBeforeBlockParameters: false
-Layout/SpaceInsideHashLiteralBraces:
-  EnforcedStyle: no_space
-Lint/AssignmentInCondition:
-  Enabled: false
-Lint/UnusedMethodArgument:
-  Enabled: false
-Metrics/AbcSize:
-  Exclude:
-    - test/**/*
-  Max: 30
+# Sinatra の configure / helpers はブロックが伸びるもので、分割しても読みやすくならない。
 Metrics/BlockLength:
   AllowedMethods:
     - configure
     - helpers
+# クライアント系クラス (ApnsClient / WnsClient / AnnouncementWorker) の実態に合わせた上限。
+# ⚠ 正本は 200。これを超える App / Database は個別に inline disable している。
 Metrics/ClassLength:
-  Exclude:
-    # テストクラスはケースを足した分だけ伸びるもので、分割しても読みやすくは
-    # ならない。Metrics/AbcSize / Layout/LineLength と同じ扱いにする。
-    - test/**/*
-  # クライアント系クラス (ApnsClient / WnsClient / AnnouncementWorker) の実態に
-  # 合わせた上限。これを超える App / Database は個別に inline disable している。
   Max: 130
-Metrics/CyclomaticComplexity:
-  Exclude:
-  Max: 10
-Metrics/MethodLength:
-  Exclude:
-  Max: 20
-Metrics/ModuleLength:
-  Exclude:
-  Max: 200
-Metrics/PerceivedComplexity:
-  Exclude:
-  Max: 10
-Naming/RescuedExceptionsVariableName:
-  PreferredName: e
-Style/AsciiComments:
-  Enabled: false
-Style/ConditionalAssignment:
-  Enabled: false
-Style/Documentation:
-  Enabled: false
-Style/EmptyMethod:
-  EnforcedStyle: expanded
-Style/FormatString:
-  EnforcedStyle: percent
-Style/FormatStringToken:
-  EnforcedStyle: template
-Style/FrozenStringLiteralComment:
-  Enabled: false
-Style/IdenticalConditionalBranches:
-  Exclude:
-    - test/**/*
-Style/IfUnlessModifier:
-  Exclude:
-    - test/**/*
-Style/RedundantReturn:
-  Enabled: false
-Style/RescueModifier:
-  Enabled: false
-Style/RescueStandardError:
-  Enabled: false
-Style/StringLiterals:
-  EnforcedStyle: single_quotes
-Style/SymbolArray:
-  EnforcedStyle: brackets
-Style/TrailingCommaInArguments:
-  EnforcedStyleForMultiline: comma
-Style/TrailingCommaInArrayLiteral:
-  EnforcedStyleForMultiline: comma
-Style/TrailingCommaInHashLiteral:
-  EnforcedStyleForMultiline: comma
-Style/WordArray:
-  EnforcedStyle: brackets
-Style/YodaCondition:
-  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -34,8 +34,7 @@ gem 'yaml'
 gem 'sentry-ruby'
 
 group :development do
-  gem 'rubocop'
-  gem 'rubocop-performance'
+  gem 'ginseng-style', github: 'pooza/ginseng-style', branch: 'main', require: false
   # テスト (#25 / #26)。Ruby 4.0 では bundled gem も Gemfile に書かないと
   # bundle 配下で require できないため明示する。flauros は
   # BUNDLE_WITHOUT=development なので本番には入らない。

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,14 @@
+GIT
+  remote: https://github.com/pooza/ginseng-style.git
+  revision: c3a40a1e34b10620b477e4d2e53838a34831d6c7
+  branch: main
+  specs:
+    ginseng-style (1.0.0)
+      rubocop
+      rubocop-minitest
+      rubocop-performance
+      rubocop-rake
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -86,10 +97,17 @@ GEM
     rubocop-ast (1.50.0)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
+    rubocop-minitest (0.40.0)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.75.0, < 2.0)
+      rubocop-ast (>= 1.38.0, < 2.0)
     rubocop-performance (1.26.1)
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.47.1, < 2.0)
+    rubocop-rake (0.7.1)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.72.1)
     ruby-progressbar (1.13.0)
     sentry-ruby (6.7.0)
       bigdecimal
@@ -137,6 +155,7 @@ PLATFORMS
 
 DEPENDENCIES
   apnotic
+  ginseng-style!
   googleauth
   json
   logger
@@ -146,8 +165,6 @@ DEPENDENCIES
   puma
   rack-test
   rake
-  rubocop
-  rubocop-performance
   sentry-ruby
   sinatra
   sqlite3
@@ -165,6 +182,7 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
+  ginseng-style (1.0.0)
   google-cloud-env (2.4.0) sha256=01cb35ecee5d1c4d1cd4deaed8bb5bddc838e296bcc2a35c5d1ddd07ce40d28d
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
   googleauth (1.17.3) sha256=9a655455885c0c17a8b70537acd2a992a7c7842c43c06c6612dfb0d93e755d58
@@ -197,7 +215,9 @@ CHECKSUMS
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
   rubocop (1.89.0) sha256=4dee8e3ee9c45e474834efd9e8d6fd031e8331c8dacdff0de4ad65ae0a6faae7
   rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
+  rubocop-minitest (0.40.0) sha256=353c698199115f12151144cf0b5a96f69bb9d77b660cf6536df2c4250c672a9d
   rubocop-performance (1.26.1) sha256=cd19b936ff196df85829d264b522fd4f98b6c89ad271fa52744a8c11b8f71834
+  rubocop-rake (0.7.1) sha256=3797f2b6810c3e9df7376c26d5f44f3475eda59eb1adc38e6f62ecf027cbae4d
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   sentry-ruby (6.7.0) sha256=b4b915d79a0395ad02106d4012aa1914641456e042ce36393f15bd1630d8db42
   signet (0.22.0) sha256=b76d495ccb07ad35dbc89f3e920665a9d8ed717141955034005d7843dcfe4780

--- a/test/apns_client_test.rb
+++ b/test/apns_client_test.rb
@@ -164,6 +164,7 @@ class ApnsClientTest < Minitest::Test
     assert(result[:success])
     refute(result[:degraded])
     sent = sent_payload(client)
+
     assert_equal('x' * 100, sent['body'])
     assert_equal('aes128gcm', sent['encoding'])
   end

--- a/test/observability_route_test.rb
+++ b/test/observability_route_test.rb
@@ -232,9 +232,11 @@ class ObservabilityRouteTest < RequestTestCase
   # (capsicum#994 がこれ)、mismatch は値が古い形で、対処が違う。
   def test_missing_secret_is_distinguished_from_a_wrong_one
     get '/metrics'
+
     assert_equal('missing', records('auth.rejected').last['reason'])
 
     get('/metrics', {}, {'HTTP_X_RELAY_SECRET' => 'not-the-secret'})
+
     assert_equal('mismatch', records('auth.rejected').last['reason'])
   end
 
@@ -260,6 +262,7 @@ class ObservabilityRouteTest < RequestTestCase
     get '/metrics'
 
     record = records('auth.rejected').last
+
     assert_equal('/metrics', record['path'])
     assert_equal('GET', record['method'])
     refute_empty(record['request_id'].to_s)


### PR DESCRIPTION
closes #49

`.rubocop.yml` を [pooza/ginseng-style](https://github.com/pooza/ginseng-style) から `inherit_gem` する形に移した。**130 行 → 17 行**。

## ⚠ 経緯（このリポジトリだけを見ても分からないので書く）

`.rubocop.yml` を持つ **22 リポジトリ**のうち **10 本が 153 行完全一致**で、本質的な差は 3 つだけだった。🔴 **drift の実害**: `Exclude: test/*` を `test/**/*` に直したのは 1 リポジトリだけで、**残り 17 リポジトリでは入れ子のテストに除外が効いていなかった**。

⚠⚠ 壊れているのは「手で直す手間」ではなく **「直した変更が全員に届いたかを誰も見ていない」**こと。詳細は [ginseng-style の docs/rationale.md](https://github.com/pooza/ginseng-style/blob/main/docs/rationale.md)、横断の受け皿は pooza/ginseng-style#1。gem 側 7 本とアプリ側 10 本は移行済み。

## ⚠ このリポジトリを対象に含めた判断

`capsicum-relay` は **ginseng に依存していない**ため対象に含めるかは保留になっていた。**設定の共通化に依存関係は要らない**ので含めた。`ginseng-style` を development group に足すだけで済む。

## ⚠ 残した固有差分

- `TargetRubyVersion: 4.0`
- `Metrics/BlockLength: AllowedMethods: [configure, helpers]`（Sinatra）
- `Metrics/ClassLength: Max: 130` — ⚠ **正本は 200 で、こちらの方が厳しい**

## ⚠ cop が 661 → 721 に増えた

旧 `.rubocop.yml` は `rubocop-performance` しか require していなかったので、**Minitest 系 55 cop と Rake 系 5 cop が一度もロードされていなかった**。⚠⚠ **minitest を使っているのに `rubocop-minitest` が入っていなかった**ことになる。

新たに出た `Minitest/EmptyLineBeforeAssertionMethods` **4 件**は `rubocop -a` で解消した（`test/apns_client_test.rb` / `test/observability_route_test.rb` に空行を 1 つずつ）。

## ⚠ このリポジトリだけ minitest

他は test-unit なので、正本は `Minitest/AssertPathExists` など 4 cop を切っている（**test-unit に存在しないメソッドへ自動修正するため**。pooza/ginseng-style#11）。このリポジトリでは切る必要が無いが、切ったままでも壊れない。再度有効化するかは別途。

## ✅ 検証

- **`--list-target-files` の差分ゼロ** — lint 対象は移行前と同じ **41 ファイル**
- `bundle exec rubocop` 緑（41 files, no offenses）
- `bundle exec rake test` が **183 runs / 393 assertions / 0 failures / 0 errors / 0 skips**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
