### PR TITLE
feat: お知らせ配信の結末を観測に残す (#44)

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -247,6 +247,33 @@ journalctl -u capsicum-relay --no-pager --since "-14 days" -o short-iso \
 
 journald は 2026-04-17（サービス開始時）から全期間残っている。経緯は [pooza/capsicum#931](https://github.com/pooza/capsicum/issues/931)。
 
+#### お知らせ（announcement）が届かないとき
+
+⚠ **通常の push とは別経路・別 counter**。上流から来た Web Push を中継する通常経路と違い、お知らせは worker が各サーバーを polling して自分で送る。`relay_push_total` には**乗らない**（#44）。
+
+見分けたい 3 択は「① そもそも購読が無い」「② 送ったが失敗した」「③ 送って成功した」で、どれも journald だけで分かる。
+
+```bash
+# ① server ごとの fan-out。購読 0 件でも 1 行出る
+journalctl -u capsicum-relay --no-pager -o cat \
+  | grep '"event":"announcement.dispatch"' \
+  | jq -r '[.ts, .server, .announcement_id, .subscriptions, (.device_types | tostring)] | @tsv'
+
+# ②③ 配送 1 通ごとの結末
+journalctl -u capsicum-relay --no-pager -o cat \
+  | grep '"event":"announcement.push.result"' \
+  | jq -r '[.ts, .device_type, .outcome, .account, .reason] | @tsv'
+```
+
+`/metrics` 側は `relay_announcement_push_total{device_type,outcome}`。`outcome` のラベル値は `relay_push_total` と揃えてあるので、「中継は成功しているのにお知らせ配信だけ落ちている」を並べて比較できる。お知らせ固有の値は次の 2 つ:
+
+| outcome | 読み方 |
+| --- | --- |
+| `unconfigured` | その device_type の push クライアントが未設定（`reason=client_unset`）か、register が受け付ける種別に配送が追いついていない（`reason=unknown_device_type`）。**購読行はあるのに 1 通も届かない**状態で、設定漏れ・配線漏れを疑う |
+| `no_result` | push クライアントが結果 Hash を返さなかった。実装の不整合 |
+
+⚠ **失敗しても再送はされない。** `mark_announcement_seen` は server 単位なので、現状は「失敗した 1 通が失われたことが数字とログに残る」ところまで（#44 の C 案）。購読単位の再送は失敗率を見てから設計する。
+
 ## ディレクトリ構成
 
 ```text

--- a/lib/relay/announcement_delivery_reporter.rb
+++ b/lib/relay/announcement_delivery_reporter.rb
@@ -1,0 +1,158 @@
+require_relative 'announcement_push_outcome'
+require_relative 'sentry_setup'
+
+module Relay
+  # お知らせ配信 1 通の結末を、構造化ログ 1 行と counter 1 つに落とす (#44)。
+  #
+  # 通常の push 経路には [Relay::PushHelpers#handle_push_result] があり、
+  # success / oversized / permanent / failed を分けて観測している。お知らせ配信
+  # ([Relay::AnnouncementWorker#deliver]) にはそれが一切なく、**push クライアント
+  # の戻り値を捨てていた**ため、失敗しても journald にも `/metrics` にも Sentry
+  # にも何も残らなかった。「お知らせが届かない」という報告が来ても relay 側に
+  # 手掛かりが無い、というのが実質いちばん痛い形だった。
+  #
+  # 結末の**解釈**は [Relay::AnnouncementPushOutcome]（通常 push 経路と同じ順序・
+  # 同じ名前）。このクラスは解釈した結果を**どこへ出すか**だけを持つ。
+  #
+  # ## seen の粒度はこの Issue では触らない（C 案）
+  #
+  # #44 本文のとおり、`mark_announcement_seen` は **server 単位で購読単位ではない**
+  # ため、「失敗したら seen を打たない」と素朴に直すと**そのサーバーの購読者全員へ
+  # 再送**になる。購読単位の配送状態を持つ改修（A 案 / B 案）は移行を伴うので、
+  # まず観測だけ入れて実際の失敗率を数字で見てから選ぶ。**このクラスは再送を実装
+  # しない** — 失敗が「見える」ようにするところまでが役割。
+  class AnnouncementDeliveryReporter
+    COUNTER = 'relay_announcement_push_total'.freeze
+    EVENT = 'announcement.push.result'.freeze
+
+    def initialize(logger:, metrics: nil, database: nil)
+      @logger = logger
+      @metrics = metrics
+      @database = database
+    end
+
+    # server ごとの fan-out を 1 行残す。**購読が 0 件でも出す。**
+    #
+    # #44 の 2026-08-18 のコメントで実際に切り分けコストが出た軸がこれで、
+    # 「そもそも購読が無い」「送ったが失敗した」「送って成功した」の 3 択のうち
+    # 1 つ目は DB を直接引かないと分からなかった（`announcement_subscriptions` に
+    # `macos` が 1 行も無く relay は送りようが無かった、というのが実際の結末）。
+    def record_dispatch(server:, announcement_id:, subs:)
+      log(
+        :info, 'announcement.dispatch',
+        msg: "Announcement dispatch: #{server} id=#{announcement_id} subs=#{subs.size}",
+        server: server, announcement_id: announcement_id,
+        subscriptions: subs.size,
+        device_types: subs.map {|sub| sub['device_type']}.tally
+      )
+    end
+
+    # push クライアントの戻り値 1 つを観測に落とす。返り値は outcome 文字列。
+    def record(sub:, server:, announcement_id:, result:)
+      outcome = Relay::AnnouncementPushOutcome.classify(result)
+      about = {server: server, announcement_id: announcement_id}
+      unregister_gone(sub) if outcome == 'gone'
+      emit(sub: sub, about: about, outcome: outcome,
+        detail: Relay::AnnouncementPushOutcome.detail(result))
+      capture(sub: sub, about: about, outcome: outcome, result: result)
+      return outcome
+    end
+
+    # device_type に対応する push クライアントが設定されていない（または register が
+    # 受け付ける device_type に配送が追いついていない）。従来は
+    # `return unless @apns` で**黙って捨てていた**ので、「購読行はあるのに 1 通も
+    # 届かない」状態が観測に出なかった（#36 の from_settings が起動時に塞いだ穴を、
+    # 配送時にも塞ぐ）。設定漏れなら定常的に出るので Sentry へは上げない。
+    def record_unconfigured(sub:, server:, announcement_id:, reason: nil)
+      emit(
+        sub: sub, about: {server: server, announcement_id: announcement_id},
+        outcome: 'unconfigured', detail: {reason: reason}.compact
+      )
+      return 'unconfigured'
+    end
+
+    # deliver が例外で落ちた。msg は従来 `report_error` が出していた 1 行と同じ文言に
+    # 保つ（journald の既存 grep を壊さない）。
+    def record_exception(sub:, server:, announcement_id:, error:)
+      emit(
+        sub: sub, about: {server: server, announcement_id: announcement_id},
+        outcome: 'exception', detail: {reason: error.class.to_s},
+        msg: "AnnouncementWorker[deliver(#{sub['device_type']})]: #{error.class}: #{error.message}"
+      )
+      Relay::SentrySetup.capture_exception(
+        error,
+        context: {announcement_worker: {
+          context: "deliver(#{sub['device_type']})",
+          server: server, announcement_id: announcement_id
+        }},
+      )
+      return 'exception'
+    end
+
+    private
+
+    def emit(sub:, about:, outcome:, detail:, msg: nil)
+      @metrics&.increment(COUNTER, {device_type: sub['device_type'], outcome: outcome})
+      log(
+        Relay::AnnouncementPushOutcome.level(outcome), EVENT,
+        msg: msg || message(sub, about, outcome),
+        outcome: outcome,
+        device_type: sub['device_type'],
+        account: sub['account'],
+        **about,
+        **detail
+      )
+    end
+
+    # 人間向けの 1 行。通常 push 側の "Pushed to windows: ..." と同じ読み方が
+    # できる形にする（docs/CLAUDE.md「配信不達の切り分け」）。
+    def message(sub, about, outcome)
+      where = "(#{about[:server]} id=#{about[:announcement_id]})"
+      return "Announcement pushed to #{sub['device_type']}: #{sub['account']} #{where}" \
+        if outcome == 'success'
+
+      return "Announcement push #{outcome} for #{sub['account']}" \
+        " (#{sub['device_type']}, #{about[:server]} id=#{about[:announcement_id]})"
+    end
+
+    # 端末が無効化された（UNREGISTERED / BadDeviceToken / WNS 404・410）。この
+    # 購読宛には二度と届かないので、お知らせ購読の行を落とす。
+    #
+    # ⚠ **親 subscription（通常 push 側）はここでは消さない。** 通常 push が同じ
+    # 端末で 404 / 410 を踏めば [Relay::PushHelpers#handle_push_gone] が
+    # `Database#unregister` を呼び、お知らせ購読も FK の CASCADE で一緒に消える。
+    # お知らせ配信だけを根拠に親を消すと、**通常 push は生きているのに端末ごと
+    # 登録解除する**危険がある（お知らせ payload 固有の失敗を端末の死と取り違える）。
+    def unregister_gone(sub)
+      id = sub['announcement_subscription_id']
+      return if id.nil? || @database.nil?
+
+      @database.unregister_announcement_subscription(id)
+    end
+
+    def capture(sub:, about:, outcome:, result:)
+      level = Relay::AnnouncementPushOutcome::LEVELS[outcome]
+      return unless level && outcome != 'unconfigured'
+
+      Relay::SentrySetup.capture_message(
+        "Announcement push #{outcome} (#{sub['device_type']})",
+        level: level == :error ? :error : :warning,
+        context: {announcement_push: context(sub, about, result)},
+      )
+    end
+
+    def context(sub, about, result)
+      return {
+        device_type: sub['device_type'],
+        account: sub['account'],
+        token: Relay::SentrySetup.mask_token(sub['token']),
+      }.merge(about).merge(Relay::AnnouncementPushOutcome.detail(result)).compact
+    end
+
+    # worker は request scope の外なので request_id は無い。event / msg の形は
+    # [Relay::BaseApp] の log_event と揃える。
+    def log(level, event, msg:, **fields)
+      @logger.public_send(level, {event: event, msg: msg}.merge(fields))
+    end
+  end
+end

--- a/lib/relay/announcement_delivery_reporter.rb
+++ b/lib/relay/announcement_delivery_reporter.rb
@@ -130,9 +130,20 @@ module Relay
       @database.unregister_announcement_subscription(id)
     end
 
+    # ⚠ **判定は `LEVELS` の引きではなく [AnnouncementPushOutcome.level] で行う**
+    # （Codex P2 / PR #51）。`wns_channelthrottled` のような **動的に組む outcome は
+    # `LEVELS` に載っていない**ので、Hash を直接引くと nil になり Sentry へ 1 件も
+    # 上がらなかった。通常 push 側 ([Relay::PushHelpers#handle_wns_status]) は
+    # 非正常な WNS ステータスを明示的に capture しており、そこと非対称になる。
+    #
+    # 除外は 2 つ:
+    # - `:info`（success / gone / `wns_dropped` 等の正常系）。通常 push 側も
+    #   handle_push_gone で Sentry へは上げていない
+    # - `unconfigured`（設定漏れ・配線漏れ）。直るまで定常的に出続けるので alert に
+    #   向かない。journald と counter には残る
     def capture(sub:, about:, outcome:, result:)
-      level = Relay::AnnouncementPushOutcome::LEVELS[outcome]
-      return unless level && outcome != 'unconfigured'
+      level = Relay::AnnouncementPushOutcome.level(outcome)
+      return if level == :info || outcome == 'unconfigured'
 
       Relay::SentrySetup.capture_message(
         "Announcement push #{outcome} (#{sub['device_type']})",

--- a/lib/relay/announcement_push_outcome.rb
+++ b/lib/relay/announcement_push_outcome.rb
@@ -1,0 +1,73 @@
+require_relative 'push_helpers'
+
+module Relay
+  # push クライアントの戻り値 1 つを outcome 文字列に解釈する (#44)。
+  #
+  # ⚠ **分岐の順序と名前は [Relay::PushHelpers#handle_push_result] と揃える。**
+  # あちらは Sinatra の helper mixin で、`status` / `halt` という request scope の
+  # side effect と一体になっているため worker からは呼べない。**解釈だけをここに
+  # 切り出して、両方から同じ名前が出るようにする** — 揃っていれば
+  # `relay_push_total` と `relay_announcement_push_total` を同じラベルで比較でき、
+  # 「上流からの中継は成功しているのにお知らせ配信だけ落ちている」が数字で見える。
+  module AnnouncementPushOutcome
+    # outcome ごとのログレベル。ここに無いものは :info。
+    LEVELS = {
+      'degraded' => :warn,
+      'oversized' => :warn,
+      'failed' => :error,
+      'no_result' => :error,
+      'exception' => :error,
+      'unconfigured' => :warn,
+    }.freeze
+
+    # ⚠ 失敗側は **oversized → permanent → failed** の順。入れ替えると、両方立った
+    # 結果（上限超過かつ permanent）が gone と呼ばれて**購読を消してしまう**。
+    def self.classify(result)
+      return 'no_result' unless result.is_a?(Hash)
+      return classify_failure(result) unless result[:success]
+
+      wns_status = result[:wns_status]
+      return "wns_#{wns_status}" if wns_status && wns_status != 'received'
+      return 'degraded' if result[:degraded]
+
+      return 'success'
+    end
+
+    def self.classify_failure(result)
+      return 'oversized' if result[:oversized]
+      return 'gone' if result[:permanent]
+
+      return 'failed'
+    end
+
+    # ⚠ **`wns_dropped` は正常系**（端末がオフライン / スリープで raw notification
+    # が queue されない）。通常 push 側で 5.5 週に 4476 件たまった実績があり (#24)、
+    # warn に上げると本当の異常（channelthrottled・鍵不在）が埋もれる。リストは
+    # PushHelpers の定数をそのまま参照する（2 箇所に持たない）。
+    def self.level(outcome)
+      return :info if benign_wns?(outcome)
+      return :warn if outcome.start_with?('wns_')
+
+      return LEVELS.fetch(outcome, :info)
+    end
+
+    def self.benign_wns?(outcome)
+      return Relay::PushHelpers::WNS_BENIGN_STATUSES.any? do |status|
+        outcome == "wns_#{status}"
+      end
+    end
+
+    # 失敗の材料になる項目だけ拾う。生のレスポンス body は載せない（通常 push 側の
+    # [Relay::PushHelpers#push_context] と同じ方針で status / reason に絞る）。
+    def self.detail(result)
+      return {} unless result.is_a?(Hash)
+
+      return {
+        status: result[:status],
+        reason: result[:reason],
+        wns_status: result[:wns_status],
+        original_size: result[:original_size],
+      }.compact
+    end
+  end
+end

--- a/lib/relay/announcement_worker.rb
+++ b/lib/relay/announcement_worker.rb
@@ -1,6 +1,7 @@
 require 'json'
 require 'net/http'
 require 'uri'
+require_relative 'announcement_delivery_reporter'
 require_relative 'sentry_setup'
 
 module Relay
@@ -23,13 +24,19 @@ module Relay
   class AnnouncementWorker # rubocop:disable Metrics/ClassLength
     DEFAULT_INTERVAL = 60
     REQUEST_TIMEOUT = 10
+    # register が受け付ける device_type (#36 で 4 種そろった)。配送できなかった
+    # ときの理由分けに使う。
+    KNOWN_DEVICE_TYPES = ['ios', 'macos', 'android', 'windows'].freeze
 
     # ⚠ ParameterLists を inline で許容している。6 つすべて**キーワード引数**で、
     # このコップが狙う「順序を覚えられない位置引数の列」にはあたらない。増えたのは
     # push クライアントが 4 種そろったためで、束ねると base_app 側の
     # `settings.respond_to?` の分岐が別の入れ物へ移るだけになる。
     # rubocop:disable Metrics/ParameterLists
-    def initialize(database:, logger:, apns: nil, fcm: nil, wns: nil, interval: DEFAULT_INTERVAL)
+    def initialize(
+      database:, logger:, apns: nil, fcm: nil, wns: nil, metrics: nil,
+      interval: DEFAULT_INTERVAL
+    )
       @database = database
       @logger = logger
       @apns = apns
@@ -37,6 +44,10 @@ module Relay
       @wns = wns
       @interval = interval
       @stop = false
+      # 配送 1 通ごとの結末を観測に落とす (#44)。
+      @reporter = Relay::AnnouncementDeliveryReporter.new(
+        logger: logger, metrics: metrics, database: database,
+      )
     end
     # rubocop:enable Metrics/ParameterLists
 
@@ -59,6 +70,10 @@ module Relay
         apns: (settings.respond_to?(:apns) ? settings.apns : nil),
         fcm: (settings.respond_to?(:fcm) ? settings.fcm : nil),
         wns: (settings.respond_to?(:wns) ? settings.wns : nil),
+        # `/metrics` の counter (#2)。App と同じインスタンスを渡す — worker は
+        # 同一プロセスの別スレッドなので、Metrics の Monitor でそのまま共有できる
+        # （workers 0 前提。Metrics のコメント参照）。
+        metrics: (settings.respond_to?(:metrics) ? settings.metrics : nil),
       )
     end
 
@@ -104,6 +119,12 @@ module Relay
         next if @database.announcement_seen?(server, id)
 
         dispatch_push(server, announcement)
+        # ⚠ **配送の成否に関わらず seen を打つ**（#44 で観測を入れた後も現状維持）。
+        # `mark_announcement_seen` は **server 単位で購読単位ではない**ので、
+        # 「失敗したら打たない」にすると 1 台の失敗でそのサーバーの購読者全員へ
+        # 再送になる。購読単位の配送状態を持つ改修（#44 の A 案 / B 案）は移行を
+        # 伴うため、まず `relay_announcement_push_total` で実際の失敗率を見てから
+        # 選ぶ。**今は「失われた 1 通が数字とログに残る」ところまで。**
         @database.mark_announcement_seen(server, id)
       end
     rescue StandardError => e
@@ -149,45 +170,86 @@ module Relay
 
     def dispatch_push(server, announcement)
       subs = @database.announcement_subscriptions_for_server(server)
+      id = announcement['id'].to_s
+      # ⚠ **空でも先に 1 行出す。** 「そもそも購読が無い」と「送ったが失敗した」を
+      # journald だけで切り分けられるようにするため (#44 の 2026-08-18 コメント)。
+      @reporter.record_dispatch(server: server, announcement_id: id, subs: subs)
       return if subs.empty?
 
       payload = build_payload(server, announcement)
       alert = build_alert(announcement)
       subs.each do |sub|
-        deliver(sub: sub, payload: payload, alert: alert)
+        deliver(sub: sub, payload: payload, alert: alert, server: server, announcement_id: id)
       end
     end
 
-    # device_type ごとの配送先。分岐は通常の push 経路
-    # ([Relay::PushHelpers#push_client_for]) と**同じ形に揃える**（#36）。
+    # お知らせ 1 通を 1 購読へ配送する。宛先の選択は [client_for]、payload の
+    # 変形は [push_to]（どちらも分岐は通常の push 経路と同じ形に揃える・#36）。
+    #
+    # ⚠ **戻り値を捨てない** (#44)。従来はここで push した結果を見ておらず、
+    # 失敗しても journald にも `/metrics` にも Sentry にも何も残らなかった。
+    # `poll_server` は dispatch 後に無条件で `mark_announcement_seen` を打つので
+    # 再送も起きず、**「お知らせが届かない」の手掛かりが relay 側に無かった**。
+    # 結末の解釈と観測は [Relay::AnnouncementDeliveryReporter] に寄せてある
+    # （seen の粒度はこの Issue では変えない。理由は同クラスのコメント）。
+    def deliver(sub:, payload:, alert:, server: nil, announcement_id: nil)
+      client = client_for(sub['device_type'])
+      unless client
+        return @reporter.record_unconfigured(
+          sub: sub, server: server, announcement_id: announcement_id,
+          reason: unavailable_reason(sub['device_type'])
+        )
+      end
+
+      result = push_to(client, sub, payload.merge('account' => sub['account']), alert)
+      return @reporter.record(
+        sub: sub, server: server, announcement_id: announcement_id, result: result,
+      )
+    rescue StandardError => e
+      return @reporter.record_exception(
+        sub: sub, server: server, announcement_id: announcement_id, error: e,
+      )
+    end
+
+    # device_type ごとの送信クライアント。未設定・未知の device_type なら nil。
+    # 分岐は通常の push 経路 ([Relay::PushHelpers#push_client_for]) と**同じ形に
+    # 揃える**（#36）。
     #
     # `macos` は iOS と同一 Bundle ID・同一 APNs Auth Key で送れるので、同じ
     # クライアントに流すだけでよい (capsicum#468)。**capsicum 側の変更は不要**:
     # iOS/macOS の Notification Service Extension は `body` / `encoding` を
-    # 持たない push を早期 guard で素通しし、ここで付ける `aps.alert` が
+    # 持たない push を早期 guard で素通しし、[push_to] が付ける `aps.alert` が
     # そのまま表示される（#17 で実測済みの挙動）。
+    def client_for(device_type)
+      case device_type
+      when 'ios', 'macos' then @apns
+      when 'android' then @fcm
+      when 'windows' then @wns
+      end
+    end
+
+    # 送れなかった理由を「設定漏れ」と「未知の device_type」で分ける。前者は
+    # 直せる不具合（base_app の配線漏れ・鍵の入れ忘れ）、後者は register 側が
+    # 受け付ける種別が増えたのに配送が追いついていない印。
+    def unavailable_reason(device_type)
+      return KNOWN_DEVICE_TYPES.include?(device_type) ? 'client_unset' : 'unknown_device_type'
+    end
+
+    # payload の変形は device_type ごとに違う（windows だけ別。下の wns_payload）。
     #
     # `windows` は WNS raw push（Phase 2 / capsicum#978）。`aps.alert` に相当する
     # OS 側の表示機構が無いので、トーストは capsicum の bg task が
-    # `announcement_body` から自分で組む。alert はここでは使わない。
-    def deliver(sub:, payload:, alert:)
-      enriched = payload.merge('account' => sub['account'])
+    # `announcement_body` から自分で組む。**alert は渡さない** — 使われない大きな
+    # 引数になるだけ。FCM data も同様。
+    def push_to(client, sub, enriched, alert)
       case sub['device_type']
       when 'ios', 'macos'
-        return unless @apns
-
-        @apns.push(device_token: sub['token'], payload: enriched, alert: alert)
+        return client.push(device_token: sub['token'], payload: enriched, alert: alert)
       when 'android'
-        return unless @fcm
-
-        @fcm.push(device_token: sub['token'], payload: enriched)
+        return client.push(device_token: sub['token'], payload: enriched)
       when 'windows'
-        return unless @wns
-
-        @wns.push(device_token: sub['token'], payload: wns_payload(enriched))
+        return client.push(device_token: sub['token'], payload: wns_payload(enriched))
       end
-    rescue StandardError => e
-      report_error("deliver(#{sub['device_type']})", e)
     end
 
     # Windows 宛だけの payload 変形 (#36 Phase 2 / capsicum#978)。

--- a/lib/relay/metrics.rb
+++ b/lib/relay/metrics.rb
@@ -20,6 +20,12 @@ module Relay
     # 出す counter の定義。`# HELP` / `# TYPE` を書くために名前と説明を持つ。
     COUNTERS = {
       'relay_push_total' => 'Web Push received from upstream, by device_type and outcome.',
+      # ⚠ relay_push_total とは**別系列**にする (#44)。あちらは上流 (Mastodon /
+      # Misskey) から来た Web Push の中継で、こちらは worker が polling して自分で
+      # 送るお知らせ配信。混ぜると「上流から来ていない」と「送って失敗した」が
+      # 同じ数字に溶ける。outcome のラベル値は両者で揃えてあるので比較はできる。
+      'relay_announcement_push_total' =>
+        'Announcement pushes sent by the polling worker, by device_type and outcome.',
       'relay_register_total' => 'Device registration changes, by action.',
       'relay_announcement_subscription_total' =>
         'Announcement subscription changes, by action.',

--- a/test/announcement_delivery_reporter_test.rb
+++ b/test/announcement_delivery_reporter_test.rb
@@ -152,6 +152,74 @@ class AnnouncementDeliveryReporterTest < Minitest::Test
     assert_includes(Relay::PushHelpers::WNS_BENIGN_STATUSES, 'dropped')
   end
 
+  # --- Sentry へ上げる / 上げない ---
+
+  # capture_message を差し替えて、上がった件数と level を見る。
+  # ⚠ minitest 6 に `stub` は無い（mock/stub は本体から外れた）ので、singleton を
+  # 自前で差し替えて ensure で戻す。gem を 1 つ増やすほどの用途ではない。
+  def capture_messages
+    captured = []
+    original = Relay::SentrySetup.method(:capture_message)
+    Relay::SentrySetup.define_singleton_method(:capture_message) do |message, level: :error, context: {}|
+      next captured << {message: message, level: level, context: context}
+    end
+    yield
+    return captured
+  ensure
+    Relay::SentrySetup.define_singleton_method(:capture_message, original)
+  end
+
+  # ⚠ **回帰テスト（Codex P2 / PR #51）。** `wns_channelthrottled` のような動的に
+  # 組む outcome は LEVELS に載っていないため、Hash を直接引く実装では Sentry へ
+  # 1 件も上がらなかった。通常 push 側 (handle_wns_status) は上げているので、
+  # ここが漏れると**お知らせだけ静かに alert が消える**。
+  def test_non_benign_wns_status_is_captured
+    captured = capture_messages do
+      record({success: true, wns_status: 'channelthrottled'}, sub: SUB.merge('device_type' => 'windows'))
+    end
+
+    assert_equal(1, captured.size)
+    assert_equal(:warning, captured.first[:level])
+  end
+
+  def test_benign_wns_status_is_not_captured
+    captured = capture_messages do
+      record({success: true, wns_status: 'dropped'}, sub: SUB.merge('device_type' => 'windows'))
+    end
+
+    assert_empty(captured)
+  end
+
+  def test_failure_is_captured_as_error
+    captured = capture_messages {record({success: false, status: 502})}
+
+    assert_equal(:error, captured.first[:level])
+  end
+
+  # 正常系は上げない（通常 push 側と同じ扱い。gone は handle_push_gone も
+  # Sentry へ上げていない）。
+  def test_success_and_gone_are_not_captured
+    captured = capture_messages do
+      record({success: true})
+      record({success: false, permanent: true})
+    end
+
+    assert_empty(captured)
+  end
+
+  # 設定漏れは直るまで定常的に出続けるので alert に向かない。journald と
+  # counter には残る。
+  def test_unconfigured_is_not_captured
+    captured = capture_messages do
+      @reporter.record_unconfigured(
+        sub: SUB, server: 'mstdn.example', announcement_id: '170', reason: 'client_unset',
+      )
+    end
+
+    assert_empty(captured)
+    assert_equal(1, counter('unconfigured'))
+  end
+
   # --- ログの中身（切り分けに要る軸） ---
 
   def test_log_carries_the_triage_fields

--- a/test/announcement_delivery_reporter_test.rb
+++ b/test/announcement_delivery_reporter_test.rb
@@ -1,0 +1,264 @@
+require_relative 'test_helper'
+require 'lib/relay/announcement_delivery_reporter'
+require 'lib/relay/metrics'
+require 'lib/relay/push_helpers'
+
+# #44: お知らせ配信が push の結末を見ていない。
+#
+# ここで固定するのは **outcome の名前と分岐の順序**、そして**どの結末が観測に
+# 出るか**の 2 点。実装本体は「失敗しても seen を打つ」現状（C 案）をそのまま
+# 残すので、テストも再送は見ない — 失敗が journald / counter に**残ること**が
+# この Issue の完了条件。
+class AnnouncementDeliveryReporterTest < Minitest::Test
+  # logger に渡された Hash をそのまま溜める。StructuredLog::FORMATTER が
+  # 1 行 1 JSON に落とす前の中身を見る（フォーマッタ自体は #2 のテスト側で固定済み）。
+  class RecordingLogger
+    attr_reader :records
+
+    def initialize
+      @records = []
+    end
+
+    [:info, :warn, :error].each do |level|
+      define_method(level) do |payload|
+        return @records << {level: level, payload: payload}
+      end
+    end
+  end
+
+  # どちらの unregister が呼ばれたかを見る差し替え。**2 つとも生やしておく**
+  # — 親 (subscriptions) を消さないことがこのクラスの契約なので、呼べない
+  # ダブルにしてしまうと「呼ばない」を確かめたことにならない。
+  class RecordingDatabase
+    attr_reader :unregistered, :unregistered_parents
+
+    def initialize
+      @unregistered = []
+      @unregistered_parents = []
+    end
+
+    def unregister_announcement_subscription(id)
+      return @unregistered << id
+    end
+
+    def unregister(id)
+      return @unregistered_parents << id
+    end
+  end
+
+  SUB = {
+    'device_type' => 'ios', 'token' => 'devicetoken0123456789',
+    'account' => 'alice@example', 'announcement_subscription_id' => 7
+  }.freeze
+
+  def setup
+    @logger = RecordingLogger.new
+    @metrics = Relay::Metrics.new
+    @database = RecordingDatabase.new
+    @reporter = Relay::AnnouncementDeliveryReporter.new(
+      logger: @logger, metrics: @metrics, database: @database,
+    )
+  end
+
+  def record(result, sub: SUB)
+    return @reporter.record(
+      sub: sub, server: 'mstdn.example', announcement_id: '170', result: result,
+    )
+  end
+
+  def last
+    return @logger.records.last
+  end
+
+  def counter(outcome, device_type: 'ios')
+    return @metrics.value(
+      'relay_announcement_push_total', {device_type: device_type, outcome: outcome}
+    )
+  end
+
+  # --- outcome の分類（通常 push 経路と同じ順序・同じ名前） ---
+
+  def test_success_is_recorded
+    assert_equal('success', record({success: true}))
+    assert_equal(1, counter('success'))
+  end
+
+  def test_failure_is_recorded_as_failed
+    assert_equal('failed', record({success: false, status: 500, reason: 'InternalServerError'}))
+    assert_equal(1, counter('failed'))
+  end
+
+  # 4KB 超過。degrade が空振りして 1 通ドロップした形（#44 の 2026-08-16 コメント）。
+  def test_oversized_is_recorded
+    assert_equal('oversized', record({success: false, oversized: true, status: 413}))
+    assert_equal(1, counter('oversized'))
+  end
+
+  def test_permanent_failure_is_recorded_as_gone
+    assert_equal('gone', record({success: false, permanent: true, reason: 'Unregistered'}))
+    assert_equal(1, counter('gone'))
+  end
+
+  # ⚠ **oversized が permanent より先**。順序を入れ替えると、両方立った結果が
+  # gone と呼ばれて**購読を消してしまう**（PushHelpers#handle_push_result と同じ順序）。
+  def test_oversized_wins_over_permanent
+    assert_equal('gone', record({success: false, permanent: true}))
+    assert_equal('oversized', record({success: false, permanent: true, oversized: true}))
+  end
+
+  # WNS は 200 でも X-WNS-NotificationStatus で実質不達を返す (#474 レビュー)。
+  def test_wns_status_is_recorded_when_not_received
+    outcome = record(
+      {success: true, wns_status: 'channelthrottled'},
+      sub: SUB.merge('device_type' => 'windows'),
+    )
+
+    assert_equal('wns_channelthrottled', outcome)
+    assert_equal(1, counter('wns_channelthrottled', device_type: 'windows'))
+  end
+
+  def test_degraded_is_recorded
+    assert_equal('degraded', record({success: true, degraded: true, original_size: 5000}))
+  end
+
+  # クライアントが Hash を返さなかった（差し替え漏れ・想定外の戻り値）。黙って
+  # 成功扱いにしない。
+  def test_non_hash_result_is_recorded_as_no_result
+    assert_equal('no_result', record(nil))
+    assert_equal(1, counter('no_result'))
+  end
+
+  # --- ログレベル（正常系を warn に上げない） ---
+
+  def test_success_is_logged_at_info
+    record({success: true})
+
+    assert_equal(:info, last[:level])
+  end
+
+  def test_failure_is_logged_at_error
+    record({success: false, status: 502})
+
+    assert_equal(:error, last[:level])
+  end
+
+  # ⚠ `dropped` は「端末がオフライン / スリープ」で raw notification が queue
+  # されないだけの**正常系**。5.5 週で 4476 件たまった実績があり (#24)、warn に
+  # 上げると本当の異常が埋もれる。判定は PushHelpers の定数を参照している。
+  def test_benign_wns_status_stays_info
+    record({success: true, wns_status: 'dropped'}, sub: SUB.merge('device_type' => 'windows'))
+
+    assert_equal(:info, last[:level])
+    assert_includes(Relay::PushHelpers::WNS_BENIGN_STATUSES, 'dropped')
+  end
+
+  # --- ログの中身（切り分けに要る軸） ---
+
+  def test_log_carries_the_triage_fields
+    record({success: false, status: 500, reason: 'boom'})
+    payload = last[:payload]
+
+    assert_equal('announcement.push.result', payload[:event])
+    assert_equal('failed', payload[:outcome])
+    assert_equal('ios', payload[:device_type])
+    assert_equal('mstdn.example', payload[:server])
+    assert_equal('170', payload[:announcement_id])
+    assert_equal('boom', payload[:reason])
+  end
+
+  # 人間向けの 1 行を捨てない（journald の grep 手順。StructuredLog 参照）。
+  def test_log_keeps_human_readable_message
+    record({success: true})
+
+    assert_match(/Announcement pushed to ios: alice@example/, last[:payload][:msg])
+  end
+
+  # --- 端末が無効化されたときの掃除 ---
+
+  def test_gone_unregisters_the_announcement_subscription
+    record({success: false, permanent: true, reason: 'BadDeviceToken'})
+
+    assert_equal([7], @database.unregistered)
+  end
+
+  # ⚠ **親 subscription は消さない。** 通常 push が同じ端末で 404 / 410 を踏めば
+  # handle_push_gone が Database#unregister を呼び、お知らせ購読も CASCADE で
+  # 消える。お知らせ配信だけを根拠に端末ごと登録解除しない。
+  def test_gone_does_not_touch_the_parent_subscription
+    record({success: false, permanent: true})
+
+    assert_empty(@database.unregistered_parents)
+  end
+
+  def test_success_does_not_unregister
+    record({success: true})
+
+    assert_empty(@database.unregistered)
+  end
+
+  # DB を持たない組み立て（テスト・起動順）でも落とさない。
+  def test_gone_survives_without_database
+    reporter = Relay::AnnouncementDeliveryReporter.new(logger: @logger, metrics: @metrics)
+
+    assert_equal('gone', reporter.record(
+      sub: SUB, server: 'mstdn.example', announcement_id: '1',
+      result: {success: false, permanent: true}
+    ))
+  end
+
+  # --- fan-out（「そもそも購読が無い」を journald だけで見分ける） ---
+
+  # ⚠ **0 件でも 1 行出す。** #44 の 2026-08-18 のコメントで実際に切り分けが
+  # 詰まった軸がこれ（macOS の購読が 1 行も無く、relay は送りようが無かった）。
+  def test_dispatch_is_logged_even_with_no_subscriptions
+    @reporter.record_dispatch(server: 'mstdn.example', announcement_id: '170', subs: [])
+    payload = last[:payload]
+
+    assert_equal('announcement.dispatch', payload[:event])
+    assert_equal(0, payload[:subscriptions])
+    assert_empty(payload[:device_types])
+  end
+
+  def test_dispatch_breaks_down_device_types
+    subs = [{'device_type' => 'ios'}, {'device_type' => 'ios'}, {'device_type' => 'windows'}]
+    @reporter.record_dispatch(server: 'mstdn.example', announcement_id: '170', subs: subs)
+
+    assert_equal({'ios' => 2, 'windows' => 1}, last[:payload][:device_types])
+  end
+
+  # --- 送れなかった（クライアント未設定 / 未知の device_type） ---
+
+  def test_unconfigured_is_recorded_with_reason
+    outcome = @reporter.record_unconfigured(
+      sub: SUB, server: 'mstdn.example', announcement_id: '170', reason: 'client_unset',
+    )
+
+    assert_equal('unconfigured', outcome)
+    assert_equal(:warn, last[:level])
+    assert_equal('client_unset', last[:payload][:reason])
+    assert_equal(1, counter('unconfigured'))
+  end
+
+  # --- 例外 ---
+
+  def test_exception_is_recorded
+    error = RuntimeError.new('boom')
+    outcome = @reporter.record_exception(
+      sub: SUB, server: 'mstdn.example', announcement_id: '170', error: error,
+    )
+
+    assert_equal('exception', outcome)
+    assert_equal(:error, last[:level])
+    assert_equal(1, counter('exception'))
+  end
+
+  # 従来 report_error が出していた 1 行と同じ文言を保つ（既存の grep を壊さない）。
+  def test_exception_keeps_the_previous_message_shape
+    @reporter.record_exception(
+      sub: SUB, server: 'mstdn.example', announcement_id: '170',
+      error: RuntimeError.new('boom')
+    )
+
+    assert_match(/AnnouncementWorker\[deliver\(ios\)\]: RuntimeError: boom/, last[:payload][:msg])
+  end
+end

--- a/test/announcement_worker_test.rb
+++ b/test/announcement_worker_test.rb
@@ -4,6 +4,8 @@ require 'logger'
 require 'lib/relay/announcement_worker'
 # 上限は WnsClient が持つ定数を参照する（テスト側に数値を写さない）。
 require 'lib/relay/wns_client'
+# 配送結果の counter (#44)。
+require 'lib/relay/metrics'
 
 # #36: お知らせ通知の配送先を macOS (Phase 1) / Windows (Phase 2) へ広げる。
 #
@@ -20,14 +22,17 @@ class AnnouncementWorkerTest < Minitest::Test
   class RecordingClient
     attr_reader :pushes
 
-    def initialize
+    def initialize(result = {success: true})
       @pushes = []
+      @result = result
     end
 
-    # 返り値は deliver 側で使われない。真偽だけを返すと
-    # Naming/PredicateMethod に引っかかるので記録した配列をそのまま返す。
+    # ⚠ **戻り値は deliver が見る** (#44)。以前は記録した配列を返していたが、
+    # 現在は push クライアントの契約どおり結果 Hash を返す必要がある
+    # （Hash でないものは outcome `no_result` として観測に出る）。
     def push(**kwargs)
-      return @pushes << kwargs
+      @pushes << kwargs
+      return @result
     end
   end
 
@@ -256,6 +261,106 @@ class AnnouncementWorkerTest < Minitest::Test
     )
 
     assert_empty(@wns.pushes)
+  end
+
+  # --- 配送の結末を観測に落とす (#44) ---
+  #
+  # reporter 単体の分岐は announcement_delivery_reporter_test が持つ。ここで見るのは
+  # **worker から reporter まで実際に配線されているか**（#36 の from_settings と同じ
+  # 理由 — 途中で落ちていても例外にならず、購読行はあるのに何も残らない形になる）。
+
+  def metrics_worker(result: {success: true})
+    @metrics = Relay::Metrics.new
+    @apns = RecordingClient.new(result)
+    return Relay::AnnouncementWorker.new(
+      database: nil, logger: Logger.new(IO::NULL), apns: @apns, metrics: @metrics,
+    )
+  end
+
+  def announcement_counter(outcome, device_type: 'macos')
+    return @metrics.value(
+      'relay_announcement_push_total', {device_type: device_type, outcome: outcome}
+    )
+  end
+
+  def deliver_via(worker, device_type: 'macos')
+    return worker.send(
+      :deliver,
+      sub: {'device_type' => device_type, 'token' => 'tok', 'account' => 'a@b'},
+      payload: {}, alert: {}, server: 'mstdn.example', announcement_id: '170'
+    )
+  end
+
+  def test_successful_delivery_is_counted
+    worker = metrics_worker
+
+    assert_equal('success', deliver_via(worker))
+    assert_equal(1, announcement_counter('success'))
+  end
+
+  # ⚠ **この Issue の主題。** 以前はここで戻り値を捨てていたため、失敗しても
+  # journald にも /metrics にも Sentry にも何も残らなかった（そのうえ poll_server は
+  # dispatch の後で無条件に mark_announcement_seen を打つので再送もされない）。
+  def test_failed_delivery_is_counted
+    worker = metrics_worker(result: {success: false, status: 502, reason: 'Unavailable'})
+
+    assert_equal('failed', deliver_via(worker))
+    assert_equal(1, announcement_counter('failed'))
+  end
+
+  # 長文のお知らせは degrade で救えず 1 通ドロップする（#44 の 2026-08-16 コメント）。
+  # 再送はこの Issue の範囲外なので、**落ちたことが数字で見える**ところまでを見る。
+  def test_oversized_delivery_is_counted
+    worker = metrics_worker(result: {success: false, oversized: true, status: 413})
+
+    assert_equal('oversized', deliver_via(worker))
+    assert_equal(1, announcement_counter('oversized'))
+  end
+
+  def test_client_exception_is_counted
+    worker = metrics_worker
+    @apns.define_singleton_method(:push) {|**_kwargs| raise(IOError, 'broken pipe')}
+
+    assert_equal('exception', deliver_via(worker))
+    assert_equal(1, announcement_counter('exception'))
+  end
+
+  # クライアント未設定は「設定漏れ」、未知の device_type は「配送が register に
+  # 追いついていない」印。どちらも従来は黙って捨てていた。
+  def test_missing_client_is_recorded_as_unconfigured
+    worker = Relay::AnnouncementWorker.new(
+      database: nil, logger: Logger.new(IO::NULL), metrics: (@metrics = Relay::Metrics.new),
+    )
+
+    assert_equal('unconfigured', deliver_via(worker))
+    assert_equal(1, announcement_counter('unconfigured'))
+  end
+
+  def test_unknown_device_type_is_recorded_as_unconfigured
+    worker = metrics_worker
+
+    assert_equal('unconfigured', deliver_via(worker, device_type: 'symbian'))
+    assert_equal(1, announcement_counter('unconfigured', device_type: 'symbian'))
+    assert_empty(@apns.pushes)
+  end
+
+  # `/metrics` の counter は App と同じインスタンスを共有する（同一プロセスの
+  # 別スレッド）。ここを渡し忘れると counter が永久に 0 のままになる。
+  def test_from_settings_wires_metrics
+    metrics = Relay::Metrics.new
+    settings = Struct.new(:apns, :metrics).new(@apns, metrics)
+    worker = Relay::AnnouncementWorker.from_settings(
+      settings, database: nil, logger: Logger.new(IO::NULL), interval: 0
+    )
+    worker.send(
+      :deliver,
+      sub: {'device_type' => 'macos', 'token' => 'tok', 'account' => 'a@b'},
+      payload: {}, alert: {}
+    )
+
+    assert_equal(
+      1, metrics.value('relay_announcement_push_total', {device_type: 'macos', outcome: 'success'})
+    )
   end
 
   # --- payload の組み立て (#36 Phase 2 / capsicum#978) ---


### PR DESCRIPTION
#44 の C 案（まず観測だけ入れる）。

## 何が問題だったか

`AnnouncementWorker#deliver` が push クライアントの戻り値を捨てていた。APNs / FCM / WNS の 5xx・`no_response`・oversized はいずれも例外にならず `{success: false, ...}` を返すだけなので、**失敗しても journald にも `/metrics` にも Sentry にも 1 行も残らなかった**。`poll_server` は `dispatch_push` の後で無条件に `mark_announcement_seen` を打つため再送も起きない。

2026-08-18 の切り分け（capsicum#981）では、24 時間ぶんの journald に `announce` が 1 件も出ず、`seen_announcements` を直接引いてようやく「dispatch はされた」と分かった。「では届いたのか」は最後まで分からなかった。

## 何を入れたか

| 追加 | 役割 |
| --- | --- |
| `Relay::AnnouncementPushOutcome` | 戻り値 1 つ → outcome 文字列。**分岐の順序と名前は `PushHelpers#handle_push_result` と揃える** |
| `Relay::AnnouncementDeliveryReporter` | 解釈した結末を構造化ログ 1 行 + counter 1 つ + Sentry に落とす |
| `relay_announcement_push_total` | `relay_push_total` とは**別系列**。中継と自発配信を混ぜない |
| `announcement.dispatch` イベント | server ごとの fan-out。**購読 0 件でも 1 行出す** |
| outcome `unconfigured` | クライアント未設定 / 未知の device_type。従来は黙って捨てていた |

これで「① そもそも購読が無い」「② 送ったが失敗した」「③ 送って成功した」が journald だけで分かる。手順は `docs/CLAUDE.md`「お知らせが届かないとき」に追加した。

## 意図的にやらなかったこと

- **再送は実装していない。** `mark_announcement_seen` は **server 単位で購読単位ではない**ので、「失敗したら seen を打たない」にすると 1 台の失敗でそのサーバーの購読者全員へ再送になる。購読単位の配送状態を持つ改修（#44 の A 案 / B 案）は移行を伴うため、`relay_announcement_push_total` で実際の失敗率を見てから選ぶ
- **親 `subscriptions` は消さない。** permanent (404 / 410) で落とすのは `announcement_subscriptions` の行だけ。端末そのものの死は通常 push 側の `handle_push_gone` が判定し、お知らせ購読は FK の CASCADE で一緒に消える。お知らせ payload 固有の失敗を端末の死と取り違えないため

## 検証

- `bundle exec rake test` … 212 runs / 456 assertions / 0 failures
- `bundle exec rubocop` … 44 files / no offenses
- 実配信での確認は #45 と同じく実お知らせ待ち（capsicum#981 と同じ制約）。ログと counter の形はテストで固定してある

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)
