### PR TITLE
feat: お知らせ APNs に dedup の手掛かりを載せる (#45)

### DIFF
--- a/lib/relay/announcement_worker.rb
+++ b/lib/relay/announcement_worker.rb
@@ -244,12 +244,46 @@ module Relay
     def push_to(client, sub, enriched, alert)
       case sub['device_type']
       when 'ios', 'macos'
-        return client.push(device_token: sub['token'], payload: enriched, alert: alert)
+        return client.push(device_token: sub['token'], payload: apns_payload(enriched),
+          alert: alert)
       when 'android'
         return client.push(device_token: sub['token'], payload: enriched)
       when 'windows'
         return client.push(device_token: sub['token'], payload: wns_payload(enriched))
       end
+    end
+
+    # iOS / macOS 宛だけの payload 変形 (#45)。dedup の手掛かり
+    # `capsicum_notification_id` を足す。
+    #
+    # **macOS でお知らせが二重に通知センターへ残る**のを掃除するためのキー。
+    # 背面のアプリでは `willPresent` が呼ばれず（プラグインの doc に 2026-06-12 の
+    # 実測として明記）OS 既定の banner が出るが、後始末役の capsicum
+    # `DeliveredPushCleaner` は**暗号化 `body` を持たない通知を解決不能＝削除対象外**
+    # にしている。お知らせは body を持たないので掃除されず、WebSocket 経路
+    # (capsicum#569) が出したローカル通知と 2 通並んだまま残る。
+    #
+    # 値を `announcement:<id>` にすると **capsicum 側は変更不要**で噛み合う:
+    # - ネイティブは `userInfo["capsicum_notification_id"]` を `stampedId` として拾う
+    # - `DeliveredPushCleaner._resolve` は `stampedId` があれば復号せず
+    #   `<account>|<stampedId>` を返す
+    # - WebSocket 側が登録するキーは `<account>|<notification id>` で、Mastodon /
+    #   Misskey の両 streaming ともお知らせの id を `announcement:<id>` にしている
+    #
+    # ⚠ **これで消えるのは通知センターの残骸だけ。** banner が 2 枚出ること自体は
+    # 消えない（macOS は NSE に didReceive を渡さず kill する・capsicum#673）。
+    # 通常の通知でも以前から同じ状態なので、これは**お知らせを通常通知と同水準に
+    # 揃える**変更。
+    #
+    # ⚠ **iOS / macOS に閉じる**（windows の変形と同じ理由）。キー 1 つで 50 バイト強
+    # 増え、APNs / FCM は 4KB 上限に対して degrade も再送も効かない（#44）。増分は
+    # 小さいが、上限に近いお知らせの余裕はそのぶん減るので、必要な経路にだけ足す。
+    # android は WebSocket 経路の dedup を持たないため、足しても使い道が無い。
+    def apns_payload(payload)
+      id = payload['announcement_id'].to_s
+      return payload if id.empty?
+
+      return payload.merge('capsicum_notification_id' => "announcement:#{id}")
     end
 
     # Windows 宛だけの payload 変形 (#36 Phase 2 / capsicum#978)。

--- a/test/announcement_worker_test.rb
+++ b/test/announcement_worker_test.rb
@@ -263,6 +263,64 @@ class AnnouncementWorkerTest < Minitest::Test
     assert_empty(@wns.pushes)
   end
 
+  # --- iOS / macOS 宛だけの dedup stamp (#45) ---
+
+  def apns_payload(device_type: 'macos', announcement_id: '42')
+    deliver(
+      device_type,
+      payload: {'notification_type' => 'announcement', 'announcement_id' => announcement_id},
+    )
+    return @apns.pushes.first[:payload]
+  end
+
+  # ⚠ **本題**。macOS 背面では willPresent が呼ばれず OS 既定の banner が出るが、
+  # DeliveredPushCleaner は body を持たない通知を「解決不能＝削除対象外」にする。
+  # このキーがあると復号せず `<account>|announcement:<id>` を返せるので、
+  # WebSocket 経路 (capsicum#569) が登録した同じキーと一致して掃除される。
+  def test_apns_payload_carries_the_dedup_stamp
+    assert_equal('announcement:42', apns_payload['capsicum_notification_id'])
+  end
+
+  # iOS も同じ payload（同一 Bundle ID・同一 APNs Auth Key）。
+  def test_ios_payload_carries_the_dedup_stamp
+    assert_equal('announcement:42', apns_payload(device_type: 'ios')['capsicum_notification_id'])
+  end
+
+  # ⚠ **値の形は capsicum 側と噛み合う契約**。両 streaming がお知らせの通知 id を
+  # `announcement:<id>` にしているので、prefix を変えるとキーが一致しなくなり、
+  # 「残骸が消えない」に静かに戻る（例外にもテスト失敗にもならない）。
+  def test_dedup_stamp_uses_the_announcement_prefix
+    assert_equal(
+      'announcement:xyz', apns_payload(announcement_id: 'xyz')['capsicum_notification_id']
+    )
+  end
+
+  # id が無い（想定外の入力）ときは足さない。`announcement:` だけのキーは
+  # capsicum 側の別のお知らせと衝突しうる。
+  def test_dedup_stamp_is_omitted_without_an_id
+    deliver('macos', payload: {'notification_type' => 'announcement'})
+
+    refute(@apns.pushes.first[:payload].key?('capsicum_notification_id'))
+  end
+
+  # ⚠ 逆向きの固定。**android / windows には足さない。** キー 1 つで 50 バイト強
+  # 増え、APNs / FCM は 4KB 上限に対して degrade も再送も効かない (#44)。android は
+  # WebSocket 経路の dedup を持たず使い道が無い。windows は in-process 側が raw push
+  # を食い止めるので二重表示自体が起きない。
+  def test_other_device_types_do_not_gain_the_dedup_stamp
+    deliver('android', payload: {'notification_type' => 'announcement', 'announcement_id' => '42'})
+    deliver('windows', payload: {'notification_type' => 'announcement', 'announcement_id' => '42'})
+
+    refute(@fcm.pushes.first[:payload].key?('capsicum_notification_id'))
+    refute(@wns.pushes.first[:payload].key?('capsicum_notification_id'))
+  end
+
+  # 共通 payload そのものは増やさない（Windows 用の announcement_body と同じ扱いで、
+  # 配送時の変形として足す）。
+  def test_common_payload_has_no_dedup_stamp
+    refute(build_payload('<p>x</p>').key?('capsicum_notification_id'))
+  end
+
   # --- 配送の結末を観測に落とす (#44) ---
   #
   # reporter 単体の分岐は announcement_delivery_reporter_test が持つ。ここで見るのは


### PR DESCRIPTION
iOS / macOS 宛のお知らせ payload に `capsicum_notification_id` を足す。値は `announcement:<announcement_id>`。

## 何が起きていたか

macOS でアプリを起動したまま背面に置くと、同じお知らせの通知が 2 通出て**両方とも通知センターに残る**。

- `willPresent` は背面では呼ばれないので、`NotificationDedupPlugin` の突き合わせが効かない（banner は OS 既定で出る）
- 背面ぶんの後始末役 `DeliveredPushCleaner` は、暗号化 `body` を持たない通知を「解決不能＝削除対象外」にする。お知らせは body を持たないので**掃除されない**
- 同時に WebSocket 経路 (capsicum#569) が同じお知らせをローカル通知として出す

## capsicum 側は変更不要

コードを読んで確認した:

- ネイティブは `userInfo["capsicum_notification_id"]` を `stampedId` として拾う（`NotificationDedupPlugin.swift:191`）
- `DeliveredPushCleaner._resolve` は `stampedId` があれば復号せず `<account>|<stampedId>` を返す
- WebSocket 側のキーは `notificationTagKey` = `<account>|<通知 id>`。お知らせの通知 id は両 streaming とも `announcement:<id>`（`mastodon_notification_streaming_test` / `misskey_notification_streaming_test` が `announcement:7` / `announcement:a1` で固定している）

＝ 両者が `<account>|announcement:<id>` で一致する。

## 範囲と限界

- ⚠ **消えるのは通知センターの残骸だけ。** banner が 2 枚出ること自体は消えない（macOS は NSE に didReceive を渡さず kill する・capsicum#673）。通常の通知でも以前から同じ状態なので、これは**お知らせを通常通知と同水準に揃える**変更
- **iOS / macOS に閉じた**（windows の payload 変形と同じ扱い）。キー 1 つで 50 バイト強増え、APNs / FCM は 4KB 上限に対して degrade も再送も効かない（#44）。android は WebSocket 経路の dedup を持たず使い道が無く、windows は in-process 側が raw push を食い止めるので二重表示が起きない
- 共通 `build_payload` は不変（配送時の変形として足す）。テストで両方向とも固定した

## 検証

- `bundle exec rake test` … 223 runs / 473 assertions / 0 failures
- `bundle exec rubocop` … 44 files / no offenses
- 実配信での確認は実お知らせ待ち（capsicum#981・#44 と同じ制約）

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)
